### PR TITLE
Fix bugs with getFile in async mode.

### DIFF
--- a/tern.js
+++ b/tern.js
@@ -217,19 +217,33 @@
     if (newText != null) updateText(file, newText);
   }
 
-  // FIXME there are re-entrancy problems in this when getFile is async
   function fetchAll(srv, c) {
+    // when in async mode, check if all files have been received
+    function finishAllAsync(srv, c) {
+        var done = true;
+        for (var i = 0; i < srv.files.length; ++i) {
+            if (!file.text) {
+                done = false;
+            }
+        }
+        if (done) c();
+    }
+      
     var done = true, returned = false;
     for (var i = 0; i < srv.files.length; ++i) {
       var file = srv.files[i];
       if (file.text != null) continue;
       if (srv.options.async) {
         done = false;
-        srv.options.getFile(file.name, function(err, text) {
-          if (err && !returned) { returned = true; return c(err); }
-          updateText(file, text || "");
-          fetchAll(srv, c);
-        });
+        // need another closure to avoid 'file' always being the last
+        // file in the array
+        (function(file){  
+            srv.options.getFile(file.name, function(err, text) {
+              if (err && !returned) { returned = true; return c(err); }
+              updateText(file, text || "");
+              finishAllAsync(srv, c);
+            });
+        })(file);
       } else {
         try {
           updateText(file, srv.options.getFile(file.name) || "");


### PR DESCRIPTION
A nested function was referring to a local in the outer function, but it was modified in a loop, so the nested function always referred to the last entry in the loop, instead of the entry when the function was created.

Also changed fetchAll to not recursively call itself in async mode.  Instead after each async files text is retrieved check to see if all the files are done.  Otherwise the same files were getting requested many times.
