### PR TITLE
Fix Issue 32. Enhancement: Allow custom column to specified for hint proposal tests.

### DIFF
--- a/test.js
+++ b/test.js
@@ -71,7 +71,7 @@ function runTests(filter) {
         var query, columnInfo = /\s*@(\d+)$/.exec(args);
         if (columnInfo) {
           var line = acorn.getLineInfo(server.files[0].text, m.index).line;
-          var endInfo = {line: line - 1, ch: parseInt(columnInfo[1])};
+          var endInfo = {line: line - 1, ch: parseInt(columnInfo[1]) - 1};
           query = {type: "completions", lineCharPositions: true, end: endInfo, file: fname};
           args = args.slice(0, columnInfo.index);
         }


### PR DESCRIPTION
Enhancement Request:

Modify //+ hint1, hint2, hint3 test syntax with an optional @columnNumber suffix to allow for intra-line proposal testing.

e.g.

"x". //+ charAt, charCodeAt, ...@5

I have a pull request for a suggested change to test.js to implement this.
