### PR TITLE
Fix for issue #31

### DIFF
--- a/desktop.js
+++ b/desktop.js
@@ -88,7 +88,7 @@ function startServer(dir, config) {
       fs.readFile(path.resolve(dir, name), "utf8", c);
     },
     defs: defs,
-    pluginOptions: plugins,
+    plugins: plugins,
     debug: true,
     async: true,
     projectDir: dir

--- a/test.js
+++ b/test.js
@@ -40,7 +40,7 @@ function serverOptions(context, text) {
     defs: getDefs(text),
     getFile: function(name) { return fs.readFileSync(path.resolve(context, name), "utf8"); },
     debug: true,
-    pluginOptions: { node: { modules: nodeModules } },
+    plugins: { node: { modules: nodeModules } },
     projectDir: context,
     plugins: getPlugins(text)
   };


### PR DESCRIPTION
See https://github.com/marijnh/tern/issues/31

Since tern.js was already using plugins instead of pluginOptions and the web implementation was also working, I updated desktop.js and test.js to use plugins.
