### PR TITLE
Add Simplified CommonJS wrapper support to requirejs plugin.

### DIFF
--- a/test/simplified_common/foo.js
+++ b/test/simplified_common/foo.js
@@ -1,0 +1,3 @@
+define(function(require, exports, module){
+  exports = {aString: "hello"}
+});

--- a/test/simplified_common/main.js
+++ b/test/simplified_common/main.js
@@ -1,0 +1,6 @@
+// plugin=requirejs
+
+define(function(require, exports, module){
+  var foo = require("foo");
+  foo.aString; //: string
+});


### PR DESCRIPTION
I've been working in a codebase with lots of simplified common JS modules, and I found this useful, so I thought maybe it would be useful to other users of tern.  

In the requirejs plugin check to see if there is only one argument, and if it is a function expression with 3 args named require, exports, and module.  If so, treat it as a Simplified CommonJS module, and get the modules type from either the return value, or the exports argument.  Also create a Fn to represent the require function passed to the module so that type information is available for all the synchronous require calls in this style module.

The Simplified CommonJS wrapper is described at http://requirejs.org/docs/api.html#cjsmodule
