### PR TITLE
[vim plugin] always create our own preview window

### DIFF
--- a/vim/tern.vim
+++ b/vim/tern.vim
@@ -223,13 +223,9 @@ if !exists('g:tern#command')
 endif
 
 function! tern#PreviewInfo(info)
-  silent! wincmd P
-  if &previewwindow
-    silent 1, $d
-  else
-    new +setlocal\ previewwindow|setlocal\ buftype=nofile|setlocal\ noswapfile
-    exe "normal z" . &previewheight . "\<cr>"
-  endif
+  pclose
+  new +setlocal\ previewwindow|setlocal\ buftype=nofile|setlocal\ noswapfile
+  exe "normal z" . &previewheight . "\<cr>"
   call append(0, split(a:info, "\n"))
   wincmd p
 endfunction


### PR DESCRIPTION
When different commands can create preview windows, it isn't a good idea to reuse and rewrite them.
