### PR TITLE
improve error handling; primitive logging

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -176,7 +176,7 @@
       if (err) return c(err);
       var file = queryType.takesFile && resolveFile(srv, files, query.file);
       if (queryType.fullFile && file.type == "part")
-        return("Can't run a " + query.type + " query on a file fragment");
+        return c("Can't run a " + query.type + " query on a file fragment");
 
       infer.withContext(srv.cx, function() {
         var result;

--- a/vim/tern.vim
+++ b/vim/tern.vim
@@ -3,12 +3,23 @@ py << endpy
 import vim, os, platform, subprocess, urllib2, webbrowser, json, re, select
 
 def tern_displayError(err):
-  vim.command("echo " + json.dumps(str(err)))
+  vim.command("echoerr " + json.dumps(str(err)))
+
+# set to True to enable request/response logging
+tern_Debug = False
+def tern_displayMessage(msg):
+  if tern_Debug:
+    vim.command("echomsg " + json.dumps(str(msg)))
 
 def tern_makeRequest(port, doc):
-  req = urllib2.urlopen("http://localhost:" + str(port) + "/", json.dumps(doc), 1)
-  data = req.read()
-  if req.getcode() >= 300:
+  tern_displayMessage(json.dumps(doc))
+  try:
+    req = urllib2.urlopen("http://localhost:" + str(port) + "/", json.dumps(doc), 1)
+    data = req.read()
+    tern_displayMessage(json.dumps(data))
+  except urllib2.HTTPError, e:
+    data = e.read()
+    tern_displayMessage(json.dumps(data))
     raise IOError(data)
   return json.loads(data)
 


### PR DESCRIPTION
- fix a case of error handling in tern.js (used to cause time-outs)
- fix request error handling in tern.vim (default urllib2 handlers raise HTTP 400 as error)
- add primitive request/response logging option in vim plugin (via :messages)
