### PR TITLE
[vim plugin] Fix TermDef command family

### DIFF
--- a/vim/tern.vim
+++ b/vim/tern.vim
@@ -256,6 +256,7 @@ def tern_lookupDefinition(cmd):
     filename = data["file"]
 
     if cmd == "edit" and filename == tern_relativeFile():
+      vim.command("normal! m`")
       vim.command("call cursor(" + str(lnum) + "," + str(col) + ")")
     else:
       vim.command(cmd + " +call\ cursor(" + str(lnum) + "," + str(col) + ") " + tern_projectDir() + "/" + filename)


### PR DESCRIPTION
TernDef command family moved the cursor only on the correct line. With this PR now the cursor move on the correct column also. Plus when using TernDef if the buffer was dirty an error showed up

```
E37: No write since last change (add ! to override)
```

now `TernDef` just move the cursor to the right location and set the ` mark to the old position.
