### PR TITLE
[vim plugin] make server reload modified files after rename

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -161,7 +161,8 @@
     var files = doc.files || [];
     for (var i = 0; i < files.length; ++i) {
       var file = files[i];
-      ensureFile(srv, file.name, file.type == "full" ? file.text : null)
+      ensureFile(srv, file.name, file.type == "full" ? file.text : null
+                               , file.type == "file" ? true : false)
     }
 
     if (!query) {
@@ -207,9 +208,9 @@
     return file;
   }
 
-  function ensureFile(srv, name, text) {
+  function ensureFile(srv, name, text, reload) {
     var known = findFile(srv.files, name);
-    if (known) {
+    if (known && !reload) {
       if (text) clearFile(srv, known, text);
       return;
     }
@@ -389,12 +390,13 @@
       for (var i = 0; i < doc.files.length; ++i) {
         var file = doc.files[i];
         if (typeof file != "object") return ".files[n] must be objects";
-        else if (typeof file.text != "string") return ".files[n].text must be a string";
         else if (typeof file.name != "string") return ".files[n].name must be a string";
+        else if (file.type == "file" && typeof file.text == "undefined") continue;
+        else if (typeof file.text != "string") return ".files[n].text must be a string";
         else if (file.type == "part") {
           if (typeof file.offset != "number" && typeof file.offsetLines != "number")
             return ".files[n].offset or .files[n].offsetLines must be a number";
-        } else if (file.type != "full") return ".files[n].type must be \"full\" or \"part\"";
+        } else if (file.type != "full") return ".files[n].type must be \"full\", \"part\" or \"file\"";
       }
     }
   }


### PR DESCRIPTION
rename leaves it to clients to execute the changes computed by server.
Clients need to send modified buffers and names of modified files.
Add type "file" (in addition to "full" and "part") for the latter, and let server reload from disk.
