### PR TITLE
[Vim plugin] fix wrong autocmd! for event reseting

### DIFF
--- a/vim/tern.vim
+++ b/vim/tern.vim
@@ -411,7 +411,7 @@ function! tern#Enable()
   let b:ternInsertActive = 0
   setlocal omnifunc=tern#Complete
   augroup TernAutoCmd
-    autocmd!
+    autocmd! * <buffer>
     autocmd BufLeave <buffer> :py tern_sendBufferIfDirty()
     autocmd CursorMoved,CursorMovedI <buffer> call tern#LookupArgumentHints()
     autocmd InsertEnter <buffer> let b:ternInsertActive = 1


### PR DESCRIPTION
`autocmd!` clears all events for other JS buffers, then it causes a bug when one opens more than 2 JS files.

I improved formatting type hints, instead of string concatenation.
