### PR TITLE
[Emacs mode] Add completion by auto-complete.el

### DIFF
--- a/emacs/tern.el
+++ b/emacs/tern.el
@@ -304,10 +304,12 @@ list of strings, giving the binary name and arguments.")
         tern-ac-complete-request-point)))
 
 ;; (makunbound 'ac-source-tern-completion)
-(ac-define-source tern-completion
-  '((candidates . tern-ac-completion-matches)
-    (prefix . tern-ac-completion-prefix)
-    (requires . -1)))
+(eval-after-load 'auto-complete
+  '(progn
+     (ac-define-source tern-completion
+       '((candidates . tern-ac-completion-matches)
+         (prefix . tern-ac-completion-prefix)
+         (requires . -1)))))
 
 (defun tern-ac-setup ()
   (interactive)
@@ -575,7 +577,7 @@ list of strings, giving the binary name and arguments.")
   (add-hook 'before-change-functions 'tern-before-change nil t)
   (add-hook 'post-command-hook 'tern-post-command nil t)
   (add-hook 'buffer-list-update-hook 'tern-left-buffer nil t)
-  (when auto-complete-mode
+  (when (and (featurep 'auto-complete) auto-complete-mode)
     (tern-ac-setup)))
 
 (defun tern-mode-disable ()


### PR DESCRIPTION
This patch adds two commands: `tern-ac-complete` and `tern-ac-dot-complete` and an option variable: `tern-ac-on-dot`.

![screenshot](https://f.cloud.github.com/assets/158801/463378/9e74d5aa-b555-11e2-84b7-952bb129f8c8.png)

This modification includes an ad-hoc state value for the variable `tern-activity-since-command`, which is asynchronous flow controlling. I'm not sure that this is valid code.
