### PR TITLE
When getFile provides an err, hints don't come up

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -227,11 +227,11 @@
     var file = new File(name);
     srv.files.push(file);
     if (text) {
-      updateText(file, text)
+      updateText(file, text);
     } else if (srv.options.async) {
       srv.startAsyncAction();
       srv.options.getFile(name, function(err, text) {
-        if (!err) updateText(file, text || "");
+        updateText(file, text || "");
         srv.finishAsyncAction(err);
       });
     } else {


### PR DESCRIPTION
The problem is the when err is not falsy, updateText isn't called which
is what eventually calls infer.parse
