### PR TITLE
Check `o.name` docstring ("doc:" was omitted from comment test)

### DIFF
--- a/test/docstrings.js
+++ b/test/docstrings.js
@@ -49,4 +49,4 @@ var o = {
 };
 
 o.getName; //doc: Get the name.
-o.name; // The name
+o.name; //doc: The name


### PR DESCRIPTION
The `doc:` comment test directive was omitted from one of the test lines in test/docstrings.js. This adds it.
