### PR TITLE
RFC for allowing plugins to annotate nodes with comments.

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -970,7 +970,7 @@
       if (node.callee.type == "MemberExpression") {
         var self = infer(node.callee.object, scope, c);
         var pName = propName(node.callee, scope, c);
-        if ((pName == "call" || pName == "apply") && 
+        if ((pName == "call" || pName == "apply") &&
             scope.fnType && scope.fnType.args.indexOf(self) > -1)
           maybeInstantiate(scope, 30);
         self.propagate(new HasMethodCall(pName, args, node.arguments, out));
@@ -1120,12 +1120,33 @@
     return found;
   }
 
+  var passes = [];
+  // Allow plugins to register to run a pass over the parsed AST.
+  // The handler will be given the AST node, a map of
+  // start>end/end>start positions of comments, and the text
+  exports.registerPass = function(pass) {
+    passes.push(pass);
+  };
+
   var parse = exports.parse = function(text) {
+    var commentsMap = {};
+    var config = {
+      // Save the start/ends in a map for easy lookup
+      onComment: function(block, comment, start, end) {
+        commentsMap[start] = end;
+        commentsMap[end] = start;
+      }
+    };
     var ast;
-    try { ast = acorn.parse(text); }
-    catch(e) { ast = acorn_loose.parse_dammit(text); }
+    try { ast = acorn.parse(text, config); }
+    catch(e) { ast = acorn_loose.parse_dammit(text, config); }
+
+    for (var i = 0; i < passes.length; i++) {
+      passes[i](ast, commentsMap, text);
+    }
 
     function attachComments(node) {
+      if (node.comments) return;
       var comments = commentsBefore(text, node.start);
       if (comments) node.comments = comments;
     }
@@ -1151,7 +1172,7 @@
     if (!scope) scope = cx.topScope;
     walk.recursive(ast, scope, null, scopeGatherer);
     walk.recursive(ast, scope, null, inferWrapper);
-    
+
     cx.curOrigin = null;
   };
 


### PR DESCRIPTION
This allows plugins to register so that they can walk the ast while using available comments to either annotate the nodes in such a way that the jsdoc module can understand it, or by creating and propagating types directly.
