### PR TITLE
Refer to plugin named "doc_comment" not incorrect plural name "doc_comments"

### DIFF
--- a/doc/demo/demo.js
+++ b/doc/demo/demo.js
@@ -64,7 +64,7 @@ function initEditor() {
       async: true,
       defs: defs,
       debug: true,
-      plugins: {requirejs: {}, doc_comments: true}
+      plugins: {requirejs: {}, doc_comment: true}
     });
   }
   registerDoc("test.js", editor.getDoc());


### PR DESCRIPTION
Typo fix.
