### PR TITLE
Add type info for $.Deferred, $.Callbacks, and $.Event

### DIFF
--- a/defs/jquery.json
+++ b/defs/jquery.json
@@ -840,6 +840,9 @@
       "!doc": "Store arbitrary data associated with the specified element and/or return the value that was set."
     },
     "Event": {
+      "!type": "fn(type: ?, props?: ?) -> +jQuery.Event",
+      "!url": "http://api.jquery.com/category/events/event-object/",
+      "!doc": "The jQuery.Event constructor is exposed and can be used when calling trigger. The new operator is optional.",
       "prototype": {
         "currentTarget":{
           "!type": "+Element",


### PR DESCRIPTION
These changes are so that tern realizes that the result of $.Deferred() is a jQuery.Deferred Object.  Same for Callbacks and Event.

``` javascript
var d = $.Deferred();
d. // previously no hints, now you get the deferred properties
```

Also adds the methods for the Callbacks object which were missing.
