### PR TITLE
Fixed custom path resolver in Require.js plugin

### DIFF
--- a/plugin/requirejs.js
+++ b/plugin/requirejs.js
@@ -33,8 +33,8 @@
       if (known) return flattenPath(base + known + ".js");
       var dir = name.match(/^([^\/]+)(\/.*)$/);
       if (dir) {
-        var known = opts.paths[dir[0]];
-        if (known) return flattenPath(base + known + dir[1] + ".js");
+        var known = opts.paths[dir[1]];
+        if (known) return flattenPath(base + known + dir[2] + ".js");
       }
     }
     return flattenPath(base + name + ".js");


### PR DESCRIPTION
Updated RegExp indexes in `resolveName` function to properly resolve modules with custom paths.
