### PR TITLE
Resolve modules by the final filename used to read the source file

### DIFF
--- a/plugin/node.js
+++ b/plugin/node.js
@@ -96,6 +96,8 @@
       }
       if (!/\.js$/.test(file)) file += ".js";
 
+      if (data.modules[file]) return data.modules[file];
+
       try {
         if (!fs.statSync(resolve(dir, file)).isFile()) return infer.ANull;
       } catch(e) { return infer.ANull; }

--- a/test/cases/node/main.js
+++ b/test/cases/node/main.js
@@ -36,7 +36,10 @@ require("./foo/../exportfunc.js"); //: fn(a: number, b: number) -> number
 
 require("./dir"); //:: {foo: string, rel: {abc: number, def: {xyz: string}}}
 
-require("mod1").mainExport.x; //: number
+var mod1 = require("mod1");
+var mod2 = require("mod1/mainfile.js");
+mod1.mainExport.x; //: number
+mod2.mainExport.x; //: number
 require("mod1/secondfile").secondExport.u; //: number
 require("mod1/dir1").foo.a; //: number
 


### PR DESCRIPTION
Fixes issue where requiring the same module by 2 paths, one which explicitly includes the package.json "main" file and one which does not, orphans the AVal created by the first require call and causes it to be empty even after type propagation.

The following test case, included in this PR, exhibits the issue:

``` diff
diff --git a/test/cases/node/main.js b/test/cases/node/main.js
index 083d12f..8502678 100644
--- a/test/cases/node/main.js
+++ b/test/cases/node/main.js
@@ -36,7 +36,10 @@ require("./foo/../exportfunc.js"); //: fn(a: number, b: number) -> number

 require("./dir"); //:: {foo: string, rel: {abc: number, def: {xyz: string}}}

-require("mod1").mainExport.x; //: number
+var mod1 = require("mod1");
+var mod2 = require("mod1/mainfile.js");
+mod1.mainExport.x; //: number
+mod2.mainExport.x; //: number
```

This yields a test failure:

```
$ bin/test
node, line 41: Expression has type
  ?
instead of expected type
  number
Ran 315 tests from 39 files.
1 failures!
```

The patch to plugin/node.js fixes the issue by not re-reading the module if we have already read in a module at this filename. Previously, modules were only being resolved at this stage by module name (and not filename).
