### PR TITLE
Support nested node.js module dependencies

### DIFF
--- a/test/cases/node/main.js
+++ b/test/cases/node/main.js
@@ -40,6 +40,7 @@ var mod1 = require("mod1");
 var mod2 = require("mod1/mainfile.js");
 mod1.mainExport.x; //: number
 mod2.mainExport.x; //: number
+mod1.fromSubdep; //: fn()
 
 require("mod1/secondfile").secondExport.u; //: number
 require("mod1/dir1").foo.a; //: number

--- a/test/cases/node_modules/mod1/mainfile.js
+++ b/test/cases/node_modules/mod1/mainfile.js
@@ -1,1 +1,3 @@
 exports.mainExport = {x: 10, y: 20};
+
+exports.fromSubdep = require("subdep1").subdepFunc;

--- a/test/cases/node_modules/mod1/node_modules/subdep1/package.json
+++ b/test/cases/node_modules/mod1/node_modules/subdep1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "subdep1",
+  "version": "0.0.1",
+  "main": "subdep1"
+}

--- a/test/cases/node_modules/mod1/node_modules/subdep1/subdep1.js
+++ b/test/cases/node_modules/mod1/node_modules/subdep1/subdep1.js
@@ -1,0 +1,1 @@
+exports.subdepFunc = function(){};

--- a/test/cases/node_modules/mod1/package.json
+++ b/test/cases/node_modules/mod1/package.json
@@ -1,1 +1,7 @@
-{"main": "mainfile.js"}
+{
+  "main": "mainfile.js",
+  "dependencies": {
+    "subdep1": "0.0.1"
+  },
+  "bundledDependencies": ["subdep1"]
+}


### PR DESCRIPTION
This PR handles nested node.js module dependencies (e.g., mod1 requires mod2, which requires mod3, where mod3 is in `mod2/node_modules/mod3`). It includes both a test case (that fails pre-PR and passes post-PR) and a patch.

The patch is somewhat sketchy because it replaces the old `resolveModule` with one that uses private node.js API functions in the `module` module (e.g., https://github.com/joyent/node/blob/master/lib/module.js#L316).

Pros of using the private node.js module API:
- handles all of the edge cases
- much less code

Cons:
- might break on old or future versions of node.js
- it is easier for the `require` behavior to diverge from the non-node.js implementation in plugin/node.js

@marijnh, your call on whether to use this patch. Also, it could probably be optimized (by caching `currentModule` per-module), but I didn't want to spend too much time on it if you want to avoid using node.js private APIs. If you decline, I can work on a patch that modifies the existing `resolveModule` func and just try to stay on top of other edge cases.
