### PR TITLE
Support inline RequireJS configuration via a custom effect on requirejs.config({...})

### DIFF
--- a/test/cases/requirejs_config/main.js
+++ b/test/cases/requirejs_config/main.js
@@ -1,0 +1,11 @@
+// plugin=requirejs
+
+requirejs.config({
+  paths: {
+    fooAlias: "../requirejs/foo"
+  }
+});
+
+require(["fooAlias"], function(foo) {
+  foo.aString; //: string
+});


### PR DESCRIPTION
Adds support for reading RequireJS configuration from `requirejs.config` calls (currently, configuration is specified in `.tern-project`).

The following test case, included at `test/cases/requirejs_config/main.js`, now passes:

``` javascript
// plugin=requirejs

requirejs.config({
  paths: {
    fooAlias: "../requirejs/foo"
  }
});

require(["fooAlias"], function(foo) {
  foo.aString; //: string
});
```

If RequireJS is specified in both `.tern-project` and via `requirejs.config`, config keys from `requirejs.config` will overwrite keys from `.tern-project`. This seemed like sensible behavior so that you can specify local dev-specific configuration if needed. 

It would be great if someone who uses tern's RequireJS support in their editor could give feedback on this PR. I don't use tern in my editor, and this patch could break things for people who rely on `.tern-project` RequireJS configs for projects that also have `requirejs.config` calls.

Technically, `requirejs.config` returns a `require()` func, but I have seen that used so rarely that I did not bother to implement support for it right now.
