### PR TITLE
Don't throw an exception when a node.js module cannot be resolved

### DIFF
--- a/plugin/node.js
+++ b/plugin/node.js
@@ -60,7 +60,9 @@
         id: parent,
         paths: module_._nodeModulePaths(path.dirname(parent))
       };
-      var file = module_._resolveFilename(name, currentModule);
+      try {
+        var file = module_._resolveFilename(name, currentModule);
+      } catch(e) { return infer.ANull; }
       var known = data.modules[file];
       if (known) {
         return data.modules[name] = known;

--- a/test/cases/node/main.js
+++ b/test/cases/node/main.js
@@ -47,6 +47,9 @@ require("mod1/dir1").foo.a; //: number
 
 require("mod1/reassign_exports").funcPropExport; //loc: 2, 15
 
+// inference should continue even if a module is not found
+require("mod_not_found"); //: ?
+
 var doc = require("mod1/doc");
 doc.f1; //doc: doc for f1
 doc.f2; //doc: doc for f2


### PR DESCRIPTION
Sorry, my recent node.js require PR changed the behavior when a `require`'d module cannot be found. This PR restores the previous behavior of just returning `infer.ANull` for unresolvable modules and adds a test of this behavior.

After https://github.com/marijnh/tern/pull/189, before this patch:

```
require("module_not_found")
```

yields

```
$ bin/test
Ran 245 tests from 29 files.
All passed.

module.js:340
    throw err;
          ^
Error: Cannot find module 'mod_not_found'
    at Function.Module._resolveFilename (module.js:338:15)
    at resolveModule (/home/sqs/src/tern/plugin/node.js:63:26)
    at /home/sqs/src/tern/plugin/node.js:95:16
    at Object.exports.IsCallee.constraint.addType (/home/sqs/src/tern/lib/infer.js:271:9)
    at withWorklist (/home/sqs/src/tern/lib/infer.js:639:21)
    at Object.extend.propagate (/home/sqs/src/tern/lib/infer.js:88:25)
    at inferExprVisitor.CallExpression (/home/sqs/src/tern/lib/infer.js:1006:16)
    at Object.CallExpression (/home/sqs/src/tern/lib/infer.js:853:7)
    at infer (/home/sqs/src/tern/lib/infer.js:1038:39)
    at Object.walk.make.Expression (/home/sqs/src/tern/lib/infer.js:1043:7)
    at c (/home/sqs/src/tern/node_modules/acorn/util/walk.js:43:37)
```

After this PR, it no longer throws an exception.

(I actually prefer hard failures when a module can't be resolved, but I think I am in the minority here.)
