### PR TITLE
Refuse to define __proto__ maybeProps

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -452,6 +452,7 @@
       return av;
     },
     getProp: function(prop) {
+      if (prop == "__proto__" || prop == "✖") return ANull;
       var found = this.hasProp(prop, true) || (this.maybeProps && this.maybeProps[prop]);
       if (found) return found;
       if (!this.maybeProps) {

--- a/test/cases/proto_doc.js
+++ b/test/cases/proto_doc.js
@@ -1,0 +1,4 @@
+var A = {};
+// foo
+A.__proto__ = 1;//: number
+A; //forAllProps:

--- a/test/runcases.js
+++ b/test/runcases.js
@@ -71,7 +71,7 @@ exports.runTests = function(filter) {
     server.addFile(fname);
     var ast = server.files[0].ast;
 
-    var typedef = /\/\/(<)?(\+|::?|:\?|doc:|loc:|refs:|exports:) *([^\r\n]*)/g, m;
+    var typedef = /\/\/(<)?(\+|::?|:\?|doc:|forAllProps:|loc:|refs:|exports:) *([^\r\n]*)/g, m;
     function fail(m, str) {
       util.failure(name + ", line " + acorn.getLineInfo(text, m.index).line + ": " + str);
     }
@@ -118,6 +118,19 @@ exports.runTests = function(filter) {
             return;
           }
           start = expr.node.start; end = expr.node.end;
+        }
+        if (kind == "forAllProps:") {
+          infer.withContext(server.cx, function() {
+            var expr = tern.findQueryExpr(server.files[0], {start: start, end: end});
+            var type = infer.expressionType(expr);
+            try {
+              type.forAllProps(function() {});
+            }/* catch (e) {
+              fail(m, "forAllProps failed");
+            }*/finally {}
+
+          });
+          return;
         }
         var query = {type: kind == "doc:" ? "documentation" : kind == "loc:" ? "definition" : kind == "refs:" ? "refs" : "type",
                      start: start, end: end,


### PR DESCRIPTION
This PR is primarily a failing test case for some unexpected behavior when setting docstrings on objects with a `__proto__`.

I believe there are other ways to trigger the error than the included `test/cases/proto_doc.js`, but I couldn't isolate any. Also, I had to add a dummy `forAllProps:` comment test directive to trigger the error (I knew it occurred when calling forAllProps but didn't know how to invoke it through the tern server in such a way to exhibit the error).

Without the patch to lib/infer.js, running the tests gives:

```
$ bin/test proto_doc
Ran 2 tests from 1 files.
All passed.

/home/sqs/src/tern/lib/infer.js:651
        list[i + 1].addType(list[i], list[i + 2]);
                    ^
TypeError: Object function toString() { [native code] } has no method 'addType'
    at withWorklist (/home/sqs/src/tern/lib/infer.js:651:21)
    at Object.extend.propagate (/home/sqs/src/tern/lib/infer.js:88:25)
    at Object.extend.forAllProps (/home/sqs/src/tern/lib/infer.js:104:12)
    at query.type (/home/sqs/src/tern/test/runcases.js:127:20)
    at Object.exports.withContext (/home/sqs/src/tern/lib/infer.js:630:18)
    at /home/sqs/src/tern/test/runcases.js:123:17
    at /home/sqs/src/tern/test/runcases.js:172:7
    at Array.forEach (native)
    at Object.exports.runTests (/home/sqs/src/tern/test/runcases.js:59:27)
    at Object.<anonymous> (/home/sqs/src/tern/bin/test:5:29)
```

With the patch, which I am not sure is correct, the tests pass.

Motivation: I saw this same error when trying to call `.forAllProperties` on all of the types defined by a number of popular node.js projects in the while (e.g., at https://github.com/caolan/nodeunit/blob/master/lib/assert.js#L99).
