### PR TITLE
Prevent property access on undefined arg.args

### DIFF
--- a/lib/def.js
+++ b/lib/def.js
@@ -148,7 +148,7 @@
     var type = new TypeParser(spec, null, base, forceNew).parseType(name, true);
     if (/^fn\(/.test(spec)) for (var i = 0; i < type.args.length; ++i) (function(i) {
       var arg = type.args[i];
-      if (arg instanceof infer.Fn && arg.args.length) addEffect(type, function(_self, fArgs) {
+      if (arg instanceof infer.Fn && arg.args && arg.args.length) addEffect(type, function(_self, fArgs) {
         var fArg = fArgs[i];
         if (fArg) fArg.propagate(new infer.IsCallee(infer.cx().topScope, arg.args, null, infer.ANull));
       });


### PR DESCRIPTION
Prevents this error message:

```
/home/anders/.vim/bundle/tern_for_vim/node_modules/tern/lib/def.js:151
    if (arg instanceof infer.Fn && arg.args.length) addEffect(type, function
                                            ^
TypeError: Cannot read property 'length' of undefined
    at /home/anders/.vim/bundle/tern_for_vim/node_modules/tern/lib/def.js:151:46
```
