### PR TITLE
[emacs mode] clean quitting ido completion

### DIFF
--- a/emacs/tern-ido-complete.el
+++ b/emacs/tern-ido-complete.el
@@ -32,11 +32,10 @@
         refined)
     (if (eq 1 (length cs))
         (setq refined cs)
-      (let* ((sym (symbol-at-point))
-             (input (when sym (symbol-name sym))))
-        (setq refined (list (ido-completing-read "" cs nil nil input)))))
+      (let ((choice (ido-completing-read
+                     "" cs nil nil (thing-at-point 'symbol))))
+        (setq refined (list choice))))
     (completion-in-region start end refined)))
-
 
 (defun tern-ido-complete ()
   (interactive)


### PR DESCRIPTION
Hi Marijn,

Thanks for merging #197. This patch fixes the appearing of `error in process filter: Quit` message when you cancel ido completion, plus shortens the `symbol-at-point` part.
