### PR TITLE
Handle optional arguments

### DIFF
--- a/plugin/doc_comment.js
+++ b/plugin/doc_comment.js
@@ -170,7 +170,13 @@
         }
       }
     }
-    return {type: type, end: pos};
+
+    var isOptional = false;
+    if (str.charAt(pos) == "=") {
+        ++pos;
+        isOptional = true;
+    }
+    return {type: type, end: pos, isOptional: isOptional};
   }
 
   function parseTypeOuter(scope, str, pos) {
@@ -202,6 +208,7 @@
           var name = m[2].slice(parsed.end).match(/^\s*([\w$]+)/);
           if (!name) continue;
           (args || (args = Object.create(null)))[name[1]] = parsed.type;
+          if (args) args[name[1]].isOptional = parsed.isOptional;
           break;
         }
       }
@@ -227,7 +234,10 @@
     if (fn && (args || ret)) {
       if (args) for (var i = 0; i < fn.argNames.length; ++i) {
         var name = fn.argNames[i], known = args[name];
-        if (known) known.propagate(fn.args[i]);
+        if (known) {
+            known.propagate(fn.args[i]);
+            if (args[name].isOptional) fn.argNames[i] += "?";
+        }
       }
       if (ret) ret.propagate(fn.retval);
     } else if (type) {


### PR DESCRIPTION
If "=" is found at the end of a type then make the parameter optional by adding a "?" to the argument name.

Fixes issue #208. 
