### PR TITLE
Add package dependency headers and autoload cookies for MELPA

### DIFF
--- a/emacs/tern-auto-complete.el
+++ b/emacs/tern-auto-complete.el
@@ -3,6 +3,7 @@
 
 ;; Author:  <m.sakurai at kiwanami.net>
 ;; Version: 0.0.1
+;; Package-Requires: ((tern "0.0.1") (auto-complete "1.4") (emacs "24"))
 
 ;;; Commentary:
 
@@ -103,6 +104,7 @@
          (prefix . tern-ac-completion-prefix)
          (requires . -1)))))
 
+;;;###autoload
 (defun tern-ac-setup ()
   "Setup auto-complete for tern-mode."
   (interactive)

--- a/emacs/tern.el
+++ b/emacs/tern.el
@@ -4,6 +4,7 @@
 ;; Author: Marijn Haverbeke
 ;; URL: http://ternjs.net/
 ;; Version: 0.0.1
+;; Package-Requires: ((json "1.2") (emacs "24"))
 
 (eval-when-compile (require 'cl))
 (require 'json)
@@ -459,6 +460,7 @@ list of strings, giving the binary name and arguments.")
 
 ;; Connection management
 
+;;;###autoload
 (defun tern-use-server (port)
   (interactive "nPort to connect to: ")
   (setf tern-known-port port))
@@ -505,6 +507,7 @@ list of strings, giving the binary name and arguments.")
 (define-key tern-mode-keymap [(control ?c) (control ?c)] 'tern-get-type)
 (define-key tern-mode-keymap [(control ?c) (control ?d)] 'tern-get-docs)
 
+;;;###autoload
 (define-minor-mode tern-mode
   "Minor mode binding to the Tern JavaScript analyzer"
   nil


### PR DESCRIPTION
It [has been requested](https://github.com/milkypostman/melpa/issues/925) that we add tern.el to MELPA: this commit makes some minor changes to accommodate package.el.

We plan to add two separate packages:
1. tern, containing "tern.el" and "tern-ido-complete.el"
2. tern-auto-complete, containing just "tern-auto-complete.el"

This will avoid forcing an installation of "auto-complete" upon tern users who don't use that completion package.

So this commit adds "Package-Requires" headers as appropriate, and also adds autoload cookies so that users will generally not need to "require" the libraries before using them.

NOTE: the code declares "lexical-binding: t", and if this feature is used, then the packages will not work for any of the many Emacs 23
users. As a result, I have declared dependencies on Emacs 24. If you don't need "lexical-binding", which would be preferable, then we should instead remove both that variable setting and the Emacs 24 dependency.

Cheers!

-Steve
