### PR TITLE
Make emacs behave correctly when completing with one option

### DIFF
--- a/emacs/tern-auto-complete.el
+++ b/emacs/tern-auto-complete.el
@@ -59,19 +59,16 @@
 (defun tern-ac-complete ()
   "Complete code at point by tern."
   (interactive)
-  (let ((cur-ac-sources ac-sources))
-    (tern-ac-complete-request
-     (lambda ()
-       (auto-complete (cons 'ac-source-tern-completion cur-ac-sources))))))
+  (tern-ac-complete-request
+   (lambda ()
+     (let ((ac-sources (cons 'ac-source-tern-completion ac-sources)))
+       (ac-start)))))
 
 (defun tern-ac-dot-complete ()
   "Insert dot and complete code at point by tern."
   (interactive)
   (insert ".")
-  (let ((cur-ac-sources ac-sources))
-    (tern-ac-complete-request
-     (lambda ()
-       (auto-complete (cons 'ac-source-tern-completion cur-ac-sources))))))
+  (tern-ac-complete))
 
 (defvar tern-ac-completion-truncate-length 22
   "[AC] truncation length for type summary.")


### PR DESCRIPTION
This fixes emacs autocompletion when there is only one candidate.
