### PR TITLE
[node plugin] Add "module" module

### DIFF
--- a/plugin/node.js
+++ b/plugin/node.js
@@ -2494,6 +2494,7 @@
         INSPECT_MAX_BYTES: "number",
         SlowBuffer: "Buffer"
       },
+      module: "?",
       timers: {
         setTimeout: {
           "!type": "fn(callback: fn(), ms: number) -> timers.Timer",

--- a/test/cases/node/main.js
+++ b/test/cases/node/main.js
@@ -29,6 +29,8 @@ require("timers").setInterval; //: fn(callback: fn(), ms: number) -> timers.Time
 setInterval; //: fn(callback: fn(), ms: number) -> timers.Timer
 setTimeout(function(){}, 10).ref; //: fn()
 
+require("module");
+
 var mymod = require("mymod");
 
 mymod.foo; //: number


### PR DESCRIPTION
The node.js `module` module is not predefined, so analyzing any node.js file with `require("module")` fails with:

```
fs.js:427
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: ENOENT, no such file or directory '/home/sqs/src/tern/test/cases/node/module'
    at Object.fs.openSync (fs.js:427:18)
    at Object.fs.readFileSync (fs.js:284:15)
    at Object.getFile (/home/sqs/src/tern/test/runcases.js:50:41)
    at ensureFile (/home/sqs/src/tern/lib/tern.js:229:36)
    at Object.signal.mixin.addFile (/home/sqs/src/tern/lib/tern.js:103:7)
    at resolveModule (/home/sqs/src/tern/plugin/node.js:70:16)
    at /home/sqs/src/tern/plugin/node.js:97:16
    at Object.exports.IsCallee.constraint.addType (/home/sqs/src/tern/lib/infer.js:274:9)
    at withWorklist (/home/sqs/src/tern/lib/infer.js:651:21)
    at Object.extend.propagate (/home/sqs/src/tern/lib/infer.js:88:25)
```

This PR adds a stub definition of the `module` module. It's somewhat unclear if the `module` module is public, but `require("module")` is mentioned at http://nodejs.org/docs/latest/api/modules.html#modules_modules and it does expose some non-underscore-prefixed properties (`globalPaths`, `wrapper`, etc.). To be safe, I've just given it a `?` type.
