### PR TITLE
[node plugin] Don't load binary *.node modules

### DIFF
--- a/plugin/node.js
+++ b/plugin/node.js
@@ -67,7 +67,7 @@
       if (known) {
         return data.modules[name] = known;
       } else {
-        server.addFile(file);
+        if (path.extname(file) != '.node') server.addFile(file);
         return data.modules[file] = data.modules[name] = new infer.AVal;
       }
     };

--- a/test/cases/node/binary.node
+++ b/test/cases/node/binary.node
@@ -1,0 +1,1 @@
+exports.binary = 1;

--- a/test/cases/node/main.js
+++ b/test/cases/node/main.js
@@ -29,6 +29,9 @@ require("timers").setInterval; //: fn(callback: fn(), ms: number) -> timers.Time
 setInterval; //: fn(callback: fn(), ms: number) -> timers.Timer
 setTimeout(function(){}, 10).ref; //: fn()
 
+// don't attempt to handle .node binary modules
+require("./binary.node").binary; //: ?
+
 var mymod = require("mymod");
 
 mymod.foo; //: number


### PR DESCRIPTION
Tern should not attempt to load [node.js binary modules (addons)](http://nodejs.org/api/addons.html), which have a `.node` file extension but are otherwise required like a standard JavaScript module (`require("foo.node")`).
