### PR TITLE
Fix type propagation when reassigning module.exports to a require()'d module

### DIFF
--- a/test/cases/node/main.js
+++ b/test/cases/node/main.js
@@ -59,6 +59,8 @@ require("mod1/dir1").foo.a; //: number
 
 require("mod1/reassign_exports").funcPropExport; //loc: 2, 15
 
+require("mod1/reassign_exports_to_required"); //:: {A: number}
+
 // inference should continue even if a module is not found
 require("mod_not_found"); //: ?
 

--- a/test/cases/node_modules/mod1/a.js
+++ b/test/cases/node_modules/mod1/a.js
@@ -1,0 +1,1 @@
+exports.A = 1;

--- a/test/cases/node_modules/mod1/reassign_exports_to_required.js
+++ b/test/cases/node_modules/mod1/reassign_exports_to_required.js
@@ -1,0 +1,1 @@
+module.exports = require('./a');


### PR DESCRIPTION
This pattern currently breaks the type inferencer:

``` javascript
module.exports = require('./a');
```

It seems to work if `./a` has previously been required (which is why I didn't reuse `secondfile.js`), but otherwise the tests fail with:

```
node, line #: Expression has type
  {}
instead of expected type
  {A: number}

```

I dug a little bit into the issue but I couldn't find a fix. I'll update this PR if/when I figure out a solution.

(I discovered this problem in socket.io's [index.js](https://github.com/LearnBoost/socket.io/blob/64f6b244b6bd79880ba2e0ba00778a2309b39d0b/index.js).)
