### PR TITLE
console.error instead of console.log to avoid corrupting condense JSON output

### DIFF
--- a/lib/def.js
+++ b/lib/def.js
@@ -254,7 +254,7 @@
       }
     }
     // Uncomment this to get feedback on your poorly written .json files
-    // if (base == infer.ANull) console.log("bad path: " + path + " (" + cx.curOrigin + ")");
+    // if (base == infer.ANull) console.error("bad path: " + path + " (" + cx.curOrigin + ")");
     cx.paths[origPath] = base == infer.ANull ? null : base;
     return base;
   };
@@ -292,7 +292,7 @@
     for (var name in spec) if (hop(spec, name) && name.charCodeAt(0) != 33) {
       var inner = spec[name];
       if (typeof inner == "string" || isSimpleAnnotation(inner)) continue;
-      if (!base.defProp) console.log("base=" + (window.badBase = base));
+      if (!base.defProp) console.error("base=" + (window.badBase = base));
       var prop = base.defProp(name);
       passOne(prop.getType(), inner, path ? path + "." + name : name).propagate(prop);
     }

--- a/lib/tern.js
+++ b/lib/tern.js
@@ -188,7 +188,7 @@
         try {
           result = queryType.run(srv, query, file);
         } catch (e) {
-          if (srv.options.debug && e.name != "TernError") console.log(e.stack);
+          if (srv.options.debug && e.name != "TernError") console.error(e.stack);
           return c(e);
         }
         c(null, result);


### PR DESCRIPTION
I noticed some invalid condense JSON output due to the use of `console.log` in debug mode. The log messages were becoming part of the JSON output. This PR makes tern log to stderr, not stdout, so that condense JSON output (or the output of other tools using tern as a library) is never corrupted by internal errors.
