### PR TITLE
[emacs mode] Avoid wrong-type-argument error in completion callback

### DIFF
--- a/emacs/tern.el
+++ b/emacs/tern.el
@@ -211,10 +211,15 @@ list of strings, giving the binary name and arguments.")
 
 ;; Completion
 
+(defun tern-completion-at-point-fn ()
+  (tern-run-query #'tern-do-complete "completions" (point)))
+
 (defun tern-completion-at-point ()
   (or (tern-completion-matches-last)
-      (lambda ()
-        (tern-run-query #'tern-do-complete "completions" (point)))))
+      ;; Do not return a closure, as calling car-safe (e.g. in
+      ;; completion-at-point) on such an object returns 'closure
+      ;; instead of nil.
+      'tern-completion-at-point-fn))
 
 (defun tern-do-complete (data)
   (let ((cs (loop for elt across (cdr (assq 'completions data)) collect elt))


### PR DESCRIPTION
Hi Marijn,

I am regularly seeing the following error when using `tern.el`'s code in conjunction with a non-standard Emacs mode:

```
Error in post-command-hook (completion-in-region--postch):
(wrong-type-argument number-or-marker-p closure)
```

It is triggered by the `completion-in-region-mode-predicate` bound in `completion-at-point`.

Commit d9fc8c16 prevents `completion-in-region-mode` from being entered via `tern-do-complete`, but is ineffective when `completion-at-point` is invoked by some other means, e.g. after the `*Completions*` buffer has been displayed.

Feel free to ignore this pull request if the error is not reproducible in your setup, but I thought I'd push it as you have visibly been fighting with `completion-in-region-mode` in the past.

Cheers, -D
