### PR TITLE
soft exit when stdin ends

### DIFF
--- a/bin/tern
+++ b/bin/tern
@@ -166,6 +166,8 @@ httpServer.listen(port, "127.0.0.1", function() {
       } catch(e) {}
     });
   }
+  process.stdin.on("data", function() { });
+  process.stdin.on("end", function() { process.exit(); });
   process.on("SIGINT", function() { process.exit(); });
   process.on("SIGTERM", function() { process.exit(); });
   console.log("Listening on port " + port);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tern",
   "license": "MIT",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": "Marijn Haverbeke <marijnh@gmail.com>",
   "description": "A JavaScript code analyzer for deep, cross-editor language support",
   "main": "lib/tern.js",


### PR DESCRIPTION
to avoid having to use `taskkill` (which prevents cleanup of `.tern-port`) on windows:
- listen to `stdin` and soft exit on `end`
- bump package version so editor plugins can refer to this

NOTES:
- matching pull request for tern_for_vim, "rely on tern soft exiting when its stdin ends"
- you'll want to check when other editor plugins close tern's stdin
