### PR TITLE
Add restrictedGlobals option

### DIFF
--- a/bin/tern
+++ b/bin/tern
@@ -118,7 +118,8 @@ function startServer(dir, config) {
     defs: defs,
     plugins: plugins,
     debug: verbose,
-    projectDir: dir
+    projectDir: dir,
+    restrictedGlobals: config.restrictedGlobals || {}
   });
 
   if (config.loadEagerly) config.loadEagerly.forEach(function(pat) {

--- a/lib/infer.js
+++ b/lib/infer.js
@@ -230,9 +230,20 @@
     }
   });
 
+  function isPermitedGlobalAssignment(prop, origin) {
+    var server  = cx.parent;
+    var permits = server.options.restrictedGlobals[prop];
+    if (permits === undefined) return true;
+    if (typeof permits == "string") return (permits == origin);
+    return (permits.indexOf(origin) > -1);
+  }
+
   var PropHasSubset = exports.PropHasSubset = constraint("prop, type, originNode", {
     addType: function(type, weight) {
       if (!(type instanceof Obj)) return;
+
+      if (type === cx.topScope && !isPermitedGlobalAssignment(this.prop, this.type.origin)) return;
+
       var prop = type.defProp(this.prop, this.originNode);
       prop.origin = this.origin;
       this.type.propagate(prop, weight);

--- a/lib/tern.js
+++ b/lib/tern.js
@@ -23,7 +23,8 @@
     getFile: function(_f, c) { if (this.async) c(null, null); },
     defs: [],
     plugins: {},
-    fetchTimeout: 1000
+    fetchTimeout: 1000,
+    restrictedGlobals: {}
   };
 
   var queryTypes = {


### PR DESCRIPTION
Keep from undesirable global variable assignment by configuration.

For example, underscore.string redefines "window._" if it is undefined, to
assign "window._.str".

```
if (typeof root._ !== "undefined") {
   ...
```

   } else {
       root._ = { str : ... };
   }

Inference engine thinks "window._" assigned twice in this case. For
workaround, manually restricts global assignment to specific file by below
config.

```
"restrictedGlobals" : {
   "_" : "lib/underscore.js"
```

   }

(Also accepts list of filenames.)

I found {"libs" : "underscore"} config works fine.
But I'm sending this request because perhaps there are other modules
affects, or some one want to use the real module to follow latest /
remain legacy one.

Thank you for creating great product :)
