### PR TITLE
Display config of Tern/Nodejs server

### DIFF
--- a/bin/tern
+++ b/bin/tern
@@ -96,11 +96,11 @@ function loadPlugins(projectDir, plugins) {
 }
 
 var projectDir = findProjectDir();
+var config = defaultConfig;
 if (projectDir) {
-  var config = readProjectFile(projectDir);
+  config = readProjectFile(projectDir);
 } else {
   projectDir = process.cwd();
-  var config = defaultConfig;
 }
 var server = startServer(projectDir, config);
 
@@ -146,6 +146,7 @@ var httpServer = require("http").createServer(function(req, resp) {
 
   var target = url.parse(req.url, true);
   if (target.pathname == "/ping") return respondSimple(resp, 200, "pong");
+  if (target.pathname == "/conf") return writeConf(resp);
   if (target.pathname != "/") return respondSimple(resp, 404, "No service at " + target.pathname);
 
   if (req.method == "POST") {
@@ -173,6 +174,11 @@ httpServer.listen(port, "127.0.0.1", function() {
   process.on("SIGTERM", function() { process.exit(); });
   console.log("Listening on port " + port);
 });
+
+function writeConf(resp) {
+  var conf = {"projectDir":projectDir, "persistent" : persistent, "verbose" : verbose, "noPortFile" : noPortFile, "port" : port, "config": config};
+  return respondSimple(resp, 200, JSON.stringify(conf, null, ' '));
+}
 
 function respondSimple(resp, status, text) {
   resp.writeHead(status, {"content-type": "text/plain"});


### PR DESCRIPTION
I'm developping a Java Tern Server which consumes Tern/Nodejs (like your tern.py used in sublime text).
It was hard for me to check taht Tern/nodejs server is configurated as you wish (ex : projectDir, etc).

So I have updated your bin/tern to gives the capability to write conf. With this patch, if your Tern/Node.js server starts on 12345 port and you go at http://localhost:12345/conf with web browser, you will see the conf as JSON. Ex : 

-----------------------------------------------------------------------------------------------
{
 "projectDir": "D:\\_Projects\\git\\tern.java\\tern.server.nodejs",
 "persistent": false,
 "verbose": false,
 "noPortFile": false,
 "port": 12345,
 "config": {
  "libs": [],
  "loadEagerly": false,
  "plugins": {},
  "ecmaScript": true
 }
}
-----------------------------------------------------------------------------------------------