### PR TITLE
"Error: Invalid !type spec: string" when loading def file

### DIFF
--- a/test/condense.js
+++ b/test/condense.js
@@ -21,6 +21,9 @@ function runTest(options) {
     if (out != expect)
       util.failure("condense/" + options.load[0] + ": Mismatch in condense output. Got " +
                    out + "\nExpected " + expect);
+
+    // Test loading the condensed defs.
+    new tern.Server({defs: [condensed]});
   });
 }
 
@@ -42,6 +45,7 @@ exports.runTests = function(filter) {
   test("double_ref");
   test("proto");
   test("generic");
+  test("type_spec");
 
   test({load: ["node_simple"], plugins: {node: true}});
   test({load: ["node_fn_export"], plugins: {node: true}});

--- a/test/condense/type_spec.js
+++ b/test/condense/type_spec.js
@@ -1,0 +1,2 @@
+function a(x) {}
+a("str");

--- a/test/condense/type_spec.json
+++ b/test/condense/type_spec.json
@@ -1,0 +1,13 @@
+{
+  "!name": "type_spec",
+  "!define": {
+    "a.!0": {
+      "!span": "11[0:11]-12[0:12]",
+      "!type": "string"
+    }
+  },
+  "a": {
+    "!span": "9[0:9]-10[0:10]",
+    "!type": "fn(x: string)"
+  }
+}


### PR DESCRIPTION
Loading some def files (with, e.g., `bin/condense --def`) with a `"!type": "string"` property such as the following:

``` json
{
  "!name": "type_spec",
  "!define": {
    "a.!0": {
      "!span": "11[0:11]-12[0:12]",
      "!type": "string"
    }
  },
  "a": {
    "!span": "9[0:9]-10[0:10]",
    "!type": "fn(x: string)"
  }
}
```

causes this error, on the current master branch:

```
$ bin/condense --def /tmp/z2.json /tmp/z.js

/home/sqs/src/github.com/sqs/tern/lib/def.js:287
        else throw new Error("Invalid !type spec: " + tp);
                   ^
Error: Invalid !type spec: string
    at passOne (/home/sqs/src/github.com/sqs/tern/lib/def.js:287:20)
    at doLoadEnvironment (/home/sqs/src/github.com/sqs/tern/lib/def.js:366:74)
    at Object.exports.load (/home/sqs/src/github.com/sqs/tern/lib/def.js:384:7)
    at /home/sqs/src/github.com/sqs/tern/lib/infer.js:630:13
    at Object.exports.withContext (/home/sqs/src/github.com/sqs/tern/lib/infer.js:642:18)
    at new exports.Context (/home/sqs/src/github.com/sqs/tern/lib/infer.js:612:13)
    at Object.signal.mixin.reset (/home/sqs/src/github.com/sqs/tern/lib/tern.js:114:17)
    at Object.exports.Server (/home/sqs/src/github.com/sqs/tern/lib/tern.js:99:10)
    at Object.<anonymous> (/home/sqs/src/github.com/sqs/tern/bin/condense:67:14)
    at Module._compile (module.js:456:26)
```

The attached commit reproduces this error when you run `bin/test`.

I'm not sure why `passOne` is getting called with the `"string"` type. The `passOne` function fails if the type is not a complex type.
