### PR TITLE
Test that condensation and loading defs preserves the defs

### DIFF
--- a/test/condense.js
+++ b/test/condense.js
@@ -13,7 +13,7 @@ function runTest(options) {
   });
   options.load.forEach(function(file) {
     server.addFile(file, fs.readFileSync(caseFile(file), "utf8"));
-  });    
+  });
   server.flush(function() {
     var condensed = condense.condense(options.include || options.load, null, {sortOutput: true});
     var out = JSON.stringify(condensed, null, 2).trim();
@@ -21,6 +21,18 @@ function runTest(options) {
     if (out != expect)
       util.failure("condense/" + options.load[0] + ": Mismatch in condense output. Got " +
                    out + "\nExpected " + expect);
+
+    // Test loading the condensed defs.
+    var server2 = new tern.Server({
+      defs: [util.ecma5, util.browser, condensed],
+      plugins: options.plugins
+    });
+    server2.flush(function() {
+      var condensed2 = condense.condense(options.include || options.load, null, {sortOutput: true});
+      if (!util.deepEqual(condensed, condensed2))
+        util.failure("condense/" + options.load[0] + ": Mismatch in condense output after loading defs. Got " +
+                     JSON.stringify(condensed2, null, 2).trim() + "\nExpected " + out);
+    });
   });
 }
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,4 +1,4 @@
-var fs = require("fs"), path = require("path");
+var assert = require("assert"), fs = require("fs"), path = require("path");
 
 var projectDir = path.resolve(__dirname, "..");
 exports.resolve = function(pth) { return path.resolve(projectDir, pth); };
@@ -7,6 +7,17 @@ exports.ecma5 = JSON.parse(fs.readFileSync(exports.resolve("defs/ecma5.json")), 
 exports.browser = JSON.parse(fs.readFileSync(exports.resolve("defs/browser.json")), "utf8");
 exports.jquery = JSON.parse(fs.readFileSync(exports.resolve("defs/jquery.json")), "utf8");
 exports.underscore = JSON.parse(fs.readFileSync(exports.resolve("defs/underscore.json")), "utf8");
+
+exports.deepEqual = function(a, b) {
+  var eq;
+  try {
+    assert.deepEqual(a, b);
+    eq = true;
+  } catch (_) {
+    eq = false;
+  }
+  return eq;
+};
 
 var files = 0, tests = 0, failed = 0;
 


### PR DESCRIPTION
This PR adds an additional step to the condense tests: reloading the condensed defs and checking to make sure they are equal to the defs that were constructed in memory. The goal of this test is to ensure that condensing and reloading defs doesn't lose information.

Currently, 5 condense test cases fail this test:

```
$ bin/test
condense/add_to_old: Mismatch in condense output after loading defs. Got {
  "!name": "add_to_old",
  "Thing": {
    "!span": "9[0:9]-14[0:14]",
    "!type": "fn()"
  }
}
Expected {
  "!name": "add_to_old",
  "Element": {
    "prototype": {
      "foo": {
        "!span": "39[2:18]-42[2:21]",
        "!type": "+Thing"
      }
    }
  },
  "Thing": {
    "!span": "9[0:9]-14[0:14]",
    "!type": "fn()"
  }
}
condense/ref_in_type: Mismatch in condense output after loading defs. Got {
  "!name": "ref_in_type",
  "out": {
    "!span": "9[0:9]-12[0:12]",
    "!type": "fn(a: ?) -> number"
  }
}
Expected {
  "!name": "ref_in_type",
  "!define": {
    "out.!0": {
      "!span": "13[0:13]-14[0:14]",
      "bar": {
        "!span": "78[3:24]-81[3:27]",
        "!type": "number"
      }
    }
  },
  "out": {
    "!span": "9[0:9]-12[0:12]",
    "!type": "fn(a: ?) -> number"
  }
}
condense/generic: Mismatch in condense output after loading defs. Got {
  "!name": "generic",
  "x": {
    "!span": "9[0:9]-10[0:10]",
    "!type": "fn(y: ?)"
  }
}
Expected {
  "!name": "generic",
  "x": {
    "!span": "9[0:9]-10[0:10]",
    "!type": "fn(y: ?) -> !0.bar"
  }
}
condense/node_fn_export: Mismatch in condense output after loading defs. Got {
  "!name": "node_fn_export",
  "!define": {
    "!node": {
      "node_fn_export": {
        "!span": "17[0:17]-42[0:42]",
        "!type": "fn(a: ?)"
      }
    }
  }
}
Expected {
  "!name": "node_fn_export",
  "!define": {
    "!node": {
      "node_fn_export": {
        "!span": "17[0:17]-42[0:42]",
        "!type": "fn(a: ?) -> !0"
      }
    }
  }
}
condense/angular_simple: Mismatch in condense output after loading defs. Got {
  "!name": "angular_simple"
}
Expected {
  "!name": "angular_simple",
  "!define": {
    "!ng": {
      "foo": {
        "!data": {
          "includes": []
        },
        "!proto": "angular.Module.prototype",
        "_inject_fooVal": {
          "!span": "32[0:32]-40[0:40]"
        }
      },
      "test": {
        "!data": {
          "includes": [
            "foo"
          ]
        },
        "!proto": "angular.Module.prototype",
        "_inject_testVal": {
          "!doc": "Doc for testVal",
          "!span": "121[4:9]-130[4:18]",
          "!type": "string"
        }
      }
    }
  }
}
Ran 367 tests from 59 files.
5 failures!
```
