### PR TITLE
Failing condense test case (triggers a stack overflow)

### DIFF
--- a/test/condense.js
+++ b/test/condense.js
@@ -58,6 +58,7 @@ exports.runTests = function(filter) {
 
   test({load: ["node_simple"], plugins: {node: true}});
   test({load: ["node_fn_export"], plugins: {node: true}});
+  test({load: ["stack_overflow"], plugins: {node: true}});
 
   test({load: ["angular_simple"], plugins: {angular: true}});
 };

--- a/test/condense/stack_overflow.js
+++ b/test/condense/stack_overflow.js
@@ -1,0 +1,6 @@
+exports.parseCertString = function parseCertString() {
+  var out = {};
+  // isolated from https://github.com/joyent/node/blob/5106cadffba559ac788a8c1b9a555a6d192d95aa/lib/tls.js#L200
+  out[3] = [out[3]];
+  return out;
+};


### PR DESCRIPTION
This PR adds a failing test case that exhibits a stack overflow bug in the condenser.

Here's the error message:

```
$ bin/test
Ran 367 tests from 59 files.
All passed.

/home/sqs/src/github.com/sqs/tern/lib/infer.js:0
(function (exports, require, module, __filename, __dirname) { // Main type inf
^
RangeError: Maximum call stack size exceeded
```

I saw this error occurring on a file in the node.js API ([tls.js](https://github.com/joyent/node/blob/5106cadffba559ac788a8c1b9a555a6d192d95aa/lib/tls.js#L200)) and isolated it to these few lines.
