### PR TITLE
Treat RequireJS dep paths as relative to current file

### DIFF
--- a/test/cases/requirejs/main.js
+++ b/test/cases/requirejs/main.js
@@ -2,7 +2,7 @@
 // environment=jquery
 // plugin=requirejs {"override": {"jquery": "=$"}}
 
-requirejs(["foo", "bar!abc", "useexports", "simplifiedcommon"], function(foo, bar, useexports, simplified) {
+requirejs(["foo", "bar!abc", "useexports", "simplifiedcommon", "subdir/zap"], function(foo, bar, useexports, simplified, zap) {
   foo.aString; //: string
   bar.aNumber; //: number
   bar.baz.bazProp; //: Date
@@ -10,6 +10,7 @@ requirejs(["foo", "bar!abc", "useexports", "simplifiedcommon"], function(foo, ba
   useexports.hello; //: bool
   simplified.hello; //: string
   simplified.func; //: fn() -> bool
+  zap; //: string
 });
 
 requirejs(["jquery"], function($) {

--- a/test/cases/requirejs/subdir/zap.js
+++ b/test/cases/requirejs/subdir/zap.js
@@ -1,0 +1,3 @@
+define(["../foo"], function(foo) {
+  return foo.aString;
+});


### PR DESCRIPTION
This PR changes the requirejs plugin to treat dependency paths as relative to the current file.

The previous behavior was as follows. Suppose we have `foo.js` and `mydir/bar.js`. If `mydir/bar.js` required `../foo.js`, then the requirejs would try to open `path.join(server.options.projectDir, "../foo.js")`. With this PR, it finds the correct `foo.js`.

Includes a passing test case.

Here's the part of the spec that describes the desired behavior: https://github.com/amdjs/amdjs-api/wiki/AMD#module-id-format-

> Relative identifiers are resolved relative to the identifier of the module in which "require" is written and called.
> ...
> Relative module ID resolution examples:
> * if module "a/b/c" asks for "../d", that resolves to "a/d"
> ...
> The dependencies ids may be relative ids, and should be resolved relative to the module being defined. In other words, relative ids are resolved relative to the module's id, and not the path used to find the module's id.

And an example of a relative RequireJS dep path in the wild: https://github.com/jquery/jquery/blob/6bff3bf7d72383c1458004d4aae454b61caa400f/src/attributes/classes.js#L2

It would be great to get someone who's experienced with RequireJS to take a look at this.
