### PR TITLE
Condenser issue triggered by usage of the "copy" !effect on both an object and its prototype

### DIFF
--- a/test/cases/proto_methods.js
+++ b/test/cases/proto_methods.js
@@ -1,0 +1,20 @@
+// environment=jquery
+
+function A() {}
+
+A.fn = A.prototype;
+
+jQuery.extend(A, {
+  foo: function() {
+    return "str";
+  }
+});
+
+jQuery.extend(A.fn, {
+  foo: function() {
+    return 123;
+  }
+});
+
+A.foo; //: fn() -> string
+(new A()).foo; //: fn() -> number

--- a/test/condense.js
+++ b/test/condense.js
@@ -54,6 +54,7 @@ exports.runTests = function(filter) {
   test("ref_in_type");
   test("double_ref");
   test("proto");
+  test({load: ["proto_methods"], plugins: {jquery: true}});
   test("generic");
 
   test({load: ["node_simple"], plugins: {node: true}});

--- a/test/condense/proto_methods.js
+++ b/test/condense/proto_methods.js
@@ -1,0 +1,15 @@
+function A() {}
+
+A.fn = A.prototype;
+
+jQuery.extend(A, {
+  foo: function() {
+    return "str";
+  }
+});
+
+jQuery.extend(A.fn, {
+  foo: function() {
+    return 123;
+  }
+});

--- a/test/condense/proto_methods.json
+++ b/test/condense/proto_methods.json
@@ -1,0 +1,18 @@
+{
+  "!name": "proto_methods",
+  "A": {
+    "!span": "9[0:9]-10[0:10]",
+    "!type": "fn()",
+    "prototype": "A.fn",
+    "fn": {
+      "foo": {
+        "!span": "128[12:2]-131[12:5]",
+        "!type": "fn() -> number"
+      }
+    }
+    "foo": {
+      "!span": "59[6:2]-62[6:5]",
+      "!type": "fn() -> string"
+    },
+  }
+}


### PR DESCRIPTION
I've attached a condenser test case that demonstrates an issue that I was able to trigger when using `jQuery.extend` (or any def with a copy !effect). I also included a non-condense test case that demonstrates that tern's inferencer handles this case properly (which suggests the problem is indeed in the condenser).

Here is the test output. I manually constructed the expected test output; it might be slightly off in the character offsets or other minor things.

```
$ bin/test proto_methods
condense/proto_methods: Mismatch in condense output. Got {
  "!name": "proto_methods",
  "A": {
    "!span": "9[0:9]-10[0:10]",
    "!type": "fn()"
  }
}
Expected {
  "!name": "proto_methods",
  "A": {
    "!span": "9[0:9]-10[0:10]",
    "!type": "fn()",
    "prototype": "A.fn",
    "fn": {
      "foo": {
        "!span": "128[12:2]-131[12:5]",
        "!type": "fn() -> number"
      }
    }
    "foo": {
      "!span": "59[6:2]-62[6:5]",
      "!type": "fn() -> string"
    },
  }
}
```
