### PR TITLE
Use correct String.prototype.length URL and docstring

### DIFF
--- a/defs/ecma5.json
+++ b/defs/ecma5.json
@@ -288,8 +288,8 @@
       "!stdProto": "String",
       "length": {
         "!type": "number",
-        "!url": "https://developer.mozilla.org/en/docs/JavaScript/Reference/Global_Objects/String",
-        "!doc": "The String global object is a constructor for strings, or a sequence of characters."
+        "!url": "https://developer.mozilla.org/en/docs/JavaScript/Reference/Global_Objects/String/length",
+        "!doc": "Represents the length of a string."
       },
       "<i>": "string",
       "charAt": {


### PR DESCRIPTION
Fixes a minor mix-up in the ecma5 def: the String constructor docs and URL were duplicated on String.prototype.length. This PR updates the def file with the correct docstring and URL.
