### PR TITLE
Store origin def paths on def AVals

### DIFF
--- a/lib/def.js
+++ b/lib/def.js
@@ -338,6 +338,7 @@
         if (inner["!doc"]) known.doc = inner["!doc"];
         if (inner["!url"]) known.url = inner["!url"];
         if (inner["!span"]) known.span = inner["!span"];
+        known.path = innerPath;
       }
     }
   }

--- a/lib/tern.js
+++ b/lib/tern.js
@@ -681,7 +681,7 @@
     if (infer.didGuess()) return {};
 
     var span = getSpan(type);
-    var result = {url: type.url, doc: type.doc, origin: type.origin};
+    var result = {url: type.url, doc: type.doc, origin: type.origin, path: type.path};
 
     if (type.types) for (var i = type.types.length - 1; i >= 0; --i) {
       var tp = type.types[i];

--- a/test/cases/def_path.js
+++ b/test/cases/def_path.js
@@ -1,0 +1,5 @@
+"".length; //path: String.prototype.length
+[].length; //path: Array.prototype.length
+
+var a = "".length;
+a; //path:

--- a/test/cases/def_type_string.js
+++ b/test/cases/def_type_string.js
@@ -1,3 +1,4 @@
 // environment=string
 
 foo; //: string
+foo; //path: foo

--- a/test/cases/node/main.js
+++ b/test/cases/node/main.js
@@ -3,6 +3,7 @@
 var fs = require("fs"), crypto = require("crypto"), tls = require("tls");
 
 fs.readFileSync; //: fn(filename: string, encoding: string) -> Buffer
+fs.readFileSync; //path: fs.readFileSync
 
 fs.stat("foobar", function(err, stats) {
   err; //: Error

--- a/test/runcases.js
+++ b/test/runcases.js
@@ -77,7 +77,7 @@ exports.runTests = function(filter) {
     if (m = text.match(/\/\/ loadfiles=\s*(.*)\s*\n/))
       m[1].split(/,\s*/g).forEach(function(f) {server.addFile(f);});
 
-    var typedef = /\/\/(<)?(\+|::?|:\?|doc:|loc:|refs:|exports:) *([^\r\n]*)/g;
+    var typedef = /\/\/(<)?(\+|::?|:\?|doc:|loc:|refs:|exports:|path:) *([^\r\n]*)/g;
     function fail(m, str) {
       util.failure(name + ", line " + acorn.getLineInfo(text, m.index).line + ": " + str);
     }
@@ -125,7 +125,7 @@ exports.runTests = function(filter) {
           }
           start = expr.node.start; end = expr.node.end;
         }
-        var query = {type: kind == "doc:" ? "documentation" : kind == "loc:" ? "definition" : kind == "refs:" ? "refs" : "type",
+        var query = {type: kind == "doc:" ? "documentation" : (kind == "loc:" || kind == "path:") ? "definition" : kind == "refs:" ? "refs" : "type",
                      start: start, end: end,
                      file: fname,
                      depth: kind == "::" ? 5 : null,
@@ -145,6 +145,9 @@ exports.runTests = function(filter) {
             else if (resp.start.line + 1 != line || resp.start.ch != col)
               fail(m, "Found definition at " + (resp.start.line + 1) + ":" + resp.start.ch +
                    " instead of expected " + line + ":" + col);
+          } else if (kind == "path:") { // Path finding test
+            if ((resp.path || '') != args)
+              fail(m, "Found path\n  " + resp.path + "\ninstead of expected path\n  " + args);
           } else if (kind == "refs:") { // Reference finding test
             var pos = /\s*(\d+),\s*(\d+)/g, mm;
             while (mm = pos.exec(args)) {


### PR DESCRIPTION
This PR adds support for storing the path (e.g., `String.prototype.length`) for a def, in addition to its origin (`ecma5`), docstring, and URL, which are already being stored.

Currently it only sets the path on AVals constructed from a definition file, not on all AVals.

Here's why it's helpful to store the path. Suppose you have `"abc".length` somewhere in your code. Currently tern will show you the type (number), docstring, and URL for the `length` identifier. But there's no way for the user, or using tern's public API, to determine that this is `String.prototype.length`. This PR makes that possible. This information will be directly helpful to some users, and it will also help people building tools on top of tern, because the combination of the origin and that path unambigiously identifies a type in tern's naming scheme.