### PR TITLE
Node plugin: transparently add all seen properties on the "constants" module as numbers

### DIFF
--- a/test/cases/node/main.js
+++ b/test/cases/node/main.js
@@ -68,4 +68,6 @@ var doc = require("mod1/doc");
 doc.f1; //doc: doc for f1
 doc.f2; //doc: doc for f2
 
+require('constants').MY_CONST; //: number
+
 module.exports. //+


### PR DESCRIPTION
This PR augments the node plugin to handle the built-in "constants" module (which contains integer constants, such as `SSL_OP_ALL` and O_RDWR`). Previously this module was not part of the public, documented Node.js API; however, a [recent commit](https://github.com/joyent/node/blob/2a0b619f7b830b2e34f1707f4428c77a6fcf33fc/doc/api/crypto.markdown#cryptosetengineengine-flags) indicates that it will be in a future release.

The attached implementation creates a fake "constants" module that transparently adds all seen properties (any property requested with `hasProp`) as a number-typed property on the module. There are 2 other possible approaches we could take:

1. Hard-code all current node.js constant names in the node plugin's definitions section.
2. At runtime, if running in node, populate the "constants" module with the keys from `require('constants')`.

I am open to those 2 alternative solutions. The pros of the attached solution are that it's future-proof and platform-independent. The downside is that it's a bit hacky. (If there's a less hacky way to achieve a similar solution, let me know.)

