### PR TITLE
Add originNode for module and filter.

### DIFF
--- a/plugin/angular.js
+++ b/plugin/angular.js
@@ -88,9 +88,10 @@
 
   infer.registerFunction("angular_callFilter", function(self, args, argNodes) {
     var mod = self.getType();
-    if (mod && argNodes && argNodes[0] && argNodes[0].type == "Literal")
+    if (mod && argNodes && argNodes[0] && argNodes[0].type == "Literal") {
       if (!mod.filters) mod.filters = {};
-        mod.filters[argNodes[0].value] = {"originNode": argNodes[0], "fnType" : argNodes[1]};
+      mod.filters[argNodes[0].value] = {"nodeOfName": argNodes[0], "fnType" : argNodes[1]};
+    }
   });
   
   infer.registerFunction("angular_callInject", function(argN) {
@@ -141,13 +142,13 @@
     return ngDefs && ngDefs.Module.getProp("prototype").getType();
   }
 
-  function declareMod(name, includes, originNode) {
+  function declareMod(name, includes, nodeOfName) {
     var cx = infer.cx(), data = cx.parent._angular;
     var proto = moduleProto(cx);
     var mod = new infer.Obj(proto || true);
     if (!proto) data.nakedModules.push(mod);
     mod.origin = cx.curOrigin;
-    mod.originNode = originNode;
+    mod.nodeOfName = nodeOfName;
     mod.injector = new Injector();
     mod.metaData = {includes: includes};
     for (var i = 0; i < includes.length; ++i) {

--- a/test/condense/angular_simple.json
+++ b/test/condense/angular_simple.json
@@ -6,6 +6,7 @@
           "includes": []
         },
         "!proto": "angular.Module.prototype",
+        "!span": "15[0:15]-20[0:20]",
         "_inject_fooVal": {
           "!span": "32[0:32]-40[0:40]",
           "info": {
@@ -21,6 +22,7 @@
           ]
         },
         "!proto": "angular.Module.prototype",
+        "!span": "76[2:15]-82[2:21]",
         "_inject_testVal": {
           "!doc": "Doc for testVal",
           "!span": "121[4:9]-130[4:18]",


### PR DESCRIPTION
It's the first patch to improve angular plugin to stores each elements of angular (modules, controllers, filters, etc) and store their node information to give the capability to "go the the definition" to an angular element.

Here this patch : 

 * store the originalNode for the module. This info is usefull to manage "go the the defition" for a module. You can see sampleat https://github.com/angelozerr/angularjs-eclipse/wiki/HTML-Features#wiki-hyperlink-1
 * store the filter in the given module in a filters object. This object contains the originalNode (like module to manage "go to the definition" for filter and fn type.

I have removed the apply of injection for filter (why it was done like this?)

Perhaps filters should be store in the metadaData of module like includes? I have created this patch to discuss about that and if you accept this patch, I will create other for controllers, services, etc