### PR TITLE
Mark context as optional for jQuery constructor.

### DIFF
--- a/defs/jquery.json
+++ b/defs/jquery.json
@@ -11,7 +11,7 @@
     }
   },
   "jQuery": {
-    "!type": "fn(selector: string, context: frameElement) -> jQuery.fn",
+    "!type": "fn(selector: string, context?: frameElement) -> jQuery.fn",
     "!url": "http://api.jquery.com/jquery/",
     "!doc": "Return a collection of matched elements either found in the DOM based on passed argument(s) or created by passing an HTML string.",
     "fn": {


### PR DESCRIPTION
According the http://api.jquery.com/jquery/ doc, the context parameter is optionnal for jQuery constructor.
