### PR TITLE
Completion inside string + sample with node.js#require

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -64,6 +64,9 @@
 
   exports.defineQueryType = function(name, desc) { queryTypes[name] = desc; };
 
+  var keywordProviders = []; 
+  exports.defineKeywordProviders = function(init) { keywordProviders.push(init); };
+
   function File(name, parent) {
     this.name = name;
     this.parent = parent;
@@ -629,8 +632,17 @@
       if (!completions.length && word.length >= 2 && query.guess !== false)
         for (var prop in srv.cx.props) gather(prop, srv.cx.props[prop][0], 0);
     } else {
-      infer.forAllLocalsAt(file.ast, wordStart, file.scope, gather);
-      if (query.includeKeywords) jsKeywords.forEach(function(kw) { gather(kw, null, 0); });
+      // completion inside string parameters of function?
+      var callExpr = getStringCallExpression(file, wordStart, wordEnd);
+      if (callExpr) {
+          for (var i = 0; i < keywordProviders.length; i++) {
+            var keywords = keywordProviders[i](callExpr);
+            if (keywords) keywords.forEach(function(kw) { gather(kw, null, 0); });
+          }
+      } else {    	
+        infer.forAllLocalsAt(file.ast, wordStart, file.scope, gather);
+        if (query.includeKeywords) jsKeywords.forEach(function(kw) { gather(kw, null, 0); });
+      }
     }
 
     if (query.sort !== false) completions.sort(compareCompletions);
@@ -638,6 +650,17 @@
     return {start: outputPos(query, file, wordStart),
             end: outputPos(query, file, wordEnd),
             completions: completions};
+  }
+    
+  function getStringCallExpression(file, wordStart, wordEnd) {
+    var callExpr = infer.findExpressionAround(file.ast, null, wordStart, file.scope, "CallExpression");
+    if (callExpr && callExpr.node.arguments) {
+      for (var i = 0; i < callExpr.node.arguments.length; i++) {
+        var nodeArg = callExpr.node.arguments[i];
+        if (isStringAround(nodeArg, wordStart, wordEnd)) return callExpr;
+      }
+    }  
+    return null;
   }
 
   function findProperties(srv, query) {

--- a/plugin/node.js
+++ b/plugin/node.js
@@ -198,6 +198,16 @@
     }
   });
 
+  tern.defineKeywordProviders(function(expression) {
+    var callee = expression.node.callee;
+    if (callee.name === 'require') {
+      var cx = infer.cx(), locals = cx.definitions.node;
+      var modules = [];
+      for(var name in cx.definitions.node) modules.push(name);
+      return modules;
+    }	
+  });
+  
   var defs = {
     "!name": "node",
     "!define": {


### PR DESCRIPTION
Here a pull request to manage completion inside string. The idea is to delegate completion to tern plugin when completion is executed inside string.

For instance for require of node.js, completion must show modules name like 'fs', 'http' : 

```
require(' // here Ctrl+Space shows modules name like 'fs', 'http' 
```

Here a screenshot with CodeMirror addon : 

![completioninsidestring](https://cloud.githubusercontent.com/assets/1932211/2891956/b97eb4d0-d537-11e3-8a0b-fe0ee21eccd0.png)

this patch is just an idea to implement string compeltion, but I think it can be more improved.

If you accept this issue, I will try to manage other tern plugins.

Hope you will like this idea.
