### PR TITLE
Only run test case files ending in .js.

### DIFF
--- a/test/runcases.js
+++ b/test/runcases.js
@@ -61,13 +61,14 @@ exports.runTests = function(filter) {
   fs.readdirSync(caseDir).forEach(function(name) {
     if (filter && name.indexOf(filter) == -1) return;
 
-    util.addFile();
     var fname = name, context = caseDir;
     if (fs.statSync(path.resolve(context, name)).isDirectory()) {
       if (name == "node_modules" || name == "defs") return;
       context = path.join(context, name);
       fname = "main.js";
     }
+    if (!/\.js$/.test(fname)) return;
+    util.addFile();
 
     var text = fs.readFileSync(path.join(context, fname), "utf8"), m;
     var server = new tern.Server(serverOptions(context, text));


### PR DESCRIPTION
Also, do not count excluded directories or files in the test file count.

This change is mostly to avoid the annoyance of editor backup/swap files (*~,
*.swp) getting pulled in and run as tests when you are in the midst of editing
test files.
