### PR TITLE
Use completion hook to manage node module inside require function.

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -606,7 +606,7 @@
       completions.push(rec);
 
       if (obj && (query.types || query.docs || query.urls || query.origins)) {
-        var val = obj.props[prop];
+        var val = obj.props ? obj.props[prop] : obj[prop];
         infer.resetGuessing();
         var type = val.getType();
         rec.guess = infer.didGuess();


### PR DESCRIPTION
Here a patch which manages completion of node module which uses your "completion" hook.

Ex :  

```
require.(' // here Ctrl+Space shows list of modules
```

I don't know if it's a clean mean to manage module completion (inside string).

Here some info about this patch : 

1) Fix resolveProjectPath for WebBrowser

```
function resolveProjectPath(server, pth) {
  var base = server.options.projectDir ? normPath(server.options.projectDir) + "/" : "";
  return resolvePath(base, normPath(pth));
}
```

I had to modify resolveProjectPath function to support WebBrowser context where server.options.projectDir is null.

2) moduleCompletion hook

In the moduleCompletion hook, I do callee.name === 'require' to check we are inside a string of require function. I don't know if it's clean mean.

3) Improvment

When completion is opened, it shows modules and other keyword like setInterval, setTimeout...(which are not modules). It should be cool if we could avoid having those keyword which are not modules.

An idea is that hook function moduleCompletion could returns a boolean which tells "don't show other keywords than modules". What do you think about that?
