### PR TITLE
Use require.resolve to find plugins in condense.

### DIFF
--- a/bin/condense
+++ b/bin/condense
@@ -36,8 +36,12 @@ loadDef("ecma5");
 function loadPlugin(name, val) {
   var found = findFile(name, "plugin", ".js");
   if (!found) {
-    console.error("Could not find plugin " + name);
-    process.exit(1);
+    try {
+      found = require.resolve("tern-" + name);
+    } catch (e) {
+      console.error("Could not find plugin " + name);
+      process.exit(1);
+    }
   }
   require(found);
   plugins[path.basename(name, ".js")] = val;


### PR DESCRIPTION
This makes the bin/condense behavior loading plugins match the bin/tern
behavior, allowing the loading of installed third-party plugins.
