### PR TITLE
Fix calls to parentDepth in tern.js.

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -228,7 +228,7 @@
     var known = srv.findFile(name);
     if (known) {
       if (text != null) clearFile(srv, known, text);
-      if (parentDepth(known.parent) > parentDepth(parent)) {
+      if (parentDepth(srv, known.parent) > parentDepth(srv, parent)) {
         known.parent = parent;
         if (known.excluded) known.excluded = null;
       }
@@ -314,7 +314,9 @@
         if (file.text == null) done = false;
         else if (file.scope == null && !file.excluded) toAnalyze.push(file);
       }
-      toAnalyze.sort(function(a, b) { return parentDepth(a.parent) - parentDepth(b.parent); });
+      toAnalyze.sort(function(a, b) {
+        return parentDepth(srv, a.parent) - parentDepth(srv, b.parent);
+      });
       for (var j = 0; j < toAnalyze.length; j++) {
         var file = toAnalyze[j];
         if (file.parent && !chargeOnBudget(srv, file)) {


### PR DESCRIPTION
None of the calls to parentDepth passed the server object, meaning parentDepth
always returned 0.

This meant that file parents were not updated as requests from new files came
in, causing a problem for minimal requirements loading in the Closure plugin
(google/tern-closure#22).
