### PR TITLE
Pass completions list to plugins. Fix #373.

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -652,7 +652,7 @@
       hookname = "completion";
     }
     if (srv.passes[hookname])
-      srv.passes[hookname].forEach(function(hook) {hook(file, wordStart, wordEnd, gather);});
+      srv.passes[hookname].forEach(function(hook) {hook(file, wordStart, wordEnd, gather, completions);});
 
     if (query.sort !== false) completions.sort(compareCompletions);
     srv.cx.completingProperty = null;


### PR DESCRIPTION
This allows plugins registering a 'completion' pass to clear or filter
the completion list of results from the Tern core.
