### PR TITLE
Add a typeAt pass so plugins can help find types.

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -690,35 +690,35 @@
       expr = infer.findExpressionAround(file.ast, start, end, file.scope);
       if (expr && (wide || (start == null ? end : start) - expr.node.start < 20 || expr.node.end - end < 20))
         return expr;
-      throw ternError("No expression at the given position.");
+      return null;
     }
   };
 
-  function findTypeAtWithPasses(srv, query, file) {
-    var type, err;
-    try {
-      var expr = findExpr(file, query);
+  function findExprOrThrow(file, query, wide) {
+    var expr = findExpr(file, query, wide);
+    if (expr) return expr;
+    throw ternError("No expression at the given position.");
+  }
+
+  function findExprType(srv, query, file, expr) {
+    var type;
+    if (expr) {
       infer.resetGuessing();
       type = infer.expressionType(expr);
-    } catch (e) {
-      err = e;
     }
     if (srv.passes["typeAt"]) {
+      var pos = resolvePos(file, query.end);
       srv.passes["typeAt"].forEach(function(hook) {
-        type = hook(file, resolvePos(file, query.end), expr, type);
+        type = hook(file, pos, expr, type);
       });
     }
-    if (err && !type) throw err;
+    if (!type) throw ternError("No type found at the given position.");
     return type;
   };
 
   function findTypeAt(srv, query, file) {
-    try {
-      var expr = findExpr(file, query);
-    } catch (e) {
-      // Suppress - findTypeAtWithPasses will throw if appropriate.
-    }
-    var type = findTypeAtWithPasses(srv, query, file);
+    var expr = findExpr(file, query);
+    var type = findExprType(srv, query, file, expr);
     if (query.preferFunction)
       type = type.getFunctionType() || type.getType();
     else
@@ -744,7 +744,8 @@
   }
 
   function findDocs(srv, query, file) {
-    var type = findTypeAtWithPasses(srv, query, file);
+    var expr = findExpr(file, query);
+    var type = findExprType(srv, query, file, expr);
     var result = {url: type.url, doc: type.doc};
     var inner = type.getType();
     if (inner) storeTypeDocs(inner, result);
@@ -787,7 +788,8 @@
   };
 
   function findDef(srv, query, file) {
-    var type = findTypeAtWithPasses(srv, query, file);
+    var expr = findExpr(file, query);
+    var type = findExprType(srv, query, file, expr);
     if (infer.didGuess()) return {};
 
     var span = getSpan(type);
@@ -879,7 +881,7 @@
   }
 
   function findRefs(srv, query, file) {
-    var expr = findExpr(file, query, true);
+    var expr = findExprOrThrow(file, query, true);
     if (expr && expr.node.type == "Identifier") {
       return findRefsToVariable(srv, query, file, expr);
     } else if (expr && expr.node.type == "MemberExpression" && !expr.node.computed) {
@@ -899,7 +901,7 @@
 
   function buildRename(srv, query, file) {
     if (typeof query.newName != "string") throw ternError(".query.newName should be a string");
-    var expr = findExpr(file, query);
+    var expr = findExprOrThrow(file, query);
     if (!expr || expr.node.type != "Identifier") throw ternError("Not at a variable.");
 
     var data = findRefsToVariable(srv, query, file, expr, query.newName), refs = data.refs;


### PR DESCRIPTION
This enables plugins to provide additional type information at a given
position in a file. This is particularly useful in locations that are
not actually Javascript expressions (like comments) but also in
locations like string literals where the string might actually serve as
a reference to another type.

Using this pass in definition, doc, and type requests means plugins can
provide information for each of those requests. In particular, it
provides a solution to #370 (hooks for definition requests).
