### PR TITLE
always enable caseInsensitive in Emacs

### DIFF
--- a/emacs/tern-auto-complete.el
+++ b/emacs/tern-auto-complete.el
@@ -50,7 +50,7 @@
    (lambda (data) 
      (tern-ac-complete-response data)
      (funcall cc))
-   `((type . "completions") (types . t) (docs . t))
+   `((type . "completions") (types . t) (docs . t) (caseInsensitive . t))
    (point)))
 
 (defun tern-ac-complete-response (data)


### PR DESCRIPTION
At present, user has to input characters correctly for `ac-source-tern-completion`.
But, `auto-complete.el` filters the candidates made by `ac-source-tern-completion` depending on `ac-ignore-case`.
Therefore, I think `caseInsensitive` should be enabled always.
