### PR TITLE
Use full path for getRequire

### DIFF
--- a/plugin/requirejs.js
+++ b/plugin/requirejs.js
@@ -45,7 +45,7 @@
       data.require = new infer.Fn("require", infer.ANull, [infer.cx().str], ["module"], new infer.AVal);
       data.require.computeRet = function(_self, _args, argNodes) {
         if (argNodes.length && argNodes[0].type == "Literal" && typeof argNodes[0].value == "string")
-          return getInterface(argNodes[0].value, data);
+          return getInterface(path.join(path.dirname(data.currentFile), argNodes[0].value), data);
         return infer.ANull;
       };
     }


### PR DESCRIPTION
Hello I was trying to run `condense` on https://github.com/metapolator/metapolator . I got an error:

```
fs.js:432
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: ENOENT, no such file or directory '/home/rrt/.local/var/repo/metapolator-rrthomas/app/lib/gonzales.cssp.node.js'
```

I am using a command line something like this:

```
condense --plugin requirejs='{"paths": { "metapolator": "./", "gonzales": "npm_converted/gonzales/lib" }}' models/CPS/elements/GenericCPSNode.js 
```

The `require` statement that causes the problem is:

```
exports.srcToCSSP = require('./gonzales.cssp.node').srcToCSSP;
```

As far as I can see, the problem is that in the `getRequire` function in the `requirejs` plugin, the call to `getInterface` does not prepend the current directory. The change in this commit does so (though, apologies, I have no idea if this change uses the correct data source or is in the correct place: I am very new to Tern), and with this change, the analysis completes fine.
