### PR TITLE
Make condense test suite runnable using the command "node test/condense.js"

### DIFF
--- a/test/condense.js
+++ b/test/condense.js
@@ -87,3 +87,6 @@ exports.runTests = function(filter) {
 
   test("recursive");
 };
+
+var filter = process.argv[2];
+exports.runTests(filter);


### PR DESCRIPTION
This allows one to run the condense test suite seperate from the other
tests, when you are working on just the condense tests.
