### PR TITLE
Minor mode for highlighting refs

### DIFF
--- a/emacs/tern.el
+++ b/emacs/tern.el
@@ -438,7 +438,7 @@ list of strings, giving the binary name and arguments.")
 (defvar tern-highlight-mode-keymap (make-sparse-keymap))
 (define-key tern-highlight-mode-keymap (kbd "C-<down>") 'tern-goto-next-symbol)
 (define-key tern-highlight-mode-keymap (kbd "C-<up>") 'tern-goto-prev-symbol)
-(define-key tern-highlight-mode-keymap (kbd "ESC") 'tern-forget-highlighting)
+(define-key tern-highlight-mode-keymap (kbd "<escape>") 'tern-forget-highlighting)
 (define-key tern-highlight-mode-keymap (kbd "C-g") 'tern-forget-highlighting)
 
 (define-minor-mode %tern-highlight-mode


### PR DESCRIPTION
To enable it, (setq tern-flash-timeout nil).  When this is the case the
overlays remain visible and you can use `C-<up>` / `C-<down>` to walk through
them.  Exit this mode with `ESC` or `C-g`.

Also binds tern-highlight-refs to `M-?`.
