### PR TITLE
tern.java core is general Java API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Thanks to a group of generous [crowd funders][2], Tern is open-source
 software, under an MIT license.
 
 There are currently plugins available for [Emacs][emacs] (and Emacs
-[company-mode][cmode]), [Vim][vim], [Sublime Text][st], [Eclipse][ec],
+[company-mode][cmode]), [Vim][vim], [Sublime Text][st], [Eclipse (and general Java API)][ec],
 [Light Table][lt], and [gedit][gedit], and built-in support in
 [Brackets][brackets] and [Edge Code][edge_code].
 


### PR DESCRIPTION
@angelozerr clearly separates tern.java core as Eclipse-independent general Java API
