### PR TITLE
Add doc for findTypeAt

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -718,7 +718,7 @@
 
   function findTypeAt(srv, query, file) {
     var expr = findExpr(file, query), exprName;
-    var type = findExprType(srv, query, file, expr);
+    var type = findExprType(srv, query, file, expr), exprType = type;
     if (query.preferFunction)
       type = type.getFunctionType() || type.getType();
     else
@@ -737,7 +737,9 @@
     var result = {guess: infer.didGuess(),
                   type: infer.toString(type, query.depth),
                   name: type && type.name,
-                  exprName: exprName};
+                  exprName: exprName,
+                  doc: exprType && exprType.doc
+    };
     if (type) storeTypeDocs(type, result);
 
     return clean(result);


### PR DESCRIPTION
This PR gives you the capability to return the doc of the expression type.

Here a sample with test-node.js file  : 

``` javascript
/** base node package */
var http = require('http');
http
```

Tern request#type :

``` json
{"query":{"type":"type","file":"test-node.js","end":55,"docs":true,"urls":true,"types":true,"file":"test-node.js"}}
```

Tern response#type:

``` json
{"type":"http","name":"http","exprName":"http","doc":"* base node package","origin":"node"}
```
