### PR TITLE
[emacs mode] Do not auto-complete in comments

### DIFF
--- a/emacs/tern-auto-complete.el
+++ b/emacs/tern-auto-complete.el
@@ -72,7 +72,8 @@
   "Insert dot and complete code at point by tern."
   (interactive)
   (insert ".")
-  (tern-ac-complete))
+  (unless (nth 4 (syntax-ppss))
+    (tern-ac-complete)))
 
 (defvar tern-ac-completion-truncate-length 22
   "[AC] truncation length for type summary.")


### PR DESCRIPTION
When writing a comment, '.' usually signifies the end of a sentence, not an expression we want to complete.

When we do want to invoke auto-complete in a comment, we can use tern-ac-complete directly.

I'm not sure this is the best way to achieve this goal, or if this is behavior everyone would want. This change makes my editing experience better, though.
