### PR TITLE
[node] validate node module declared inside require function (with tern-lint)

### DIFF
--- a/plugin/node.js
+++ b/plugin/node.js
@@ -298,9 +298,13 @@
         if (!mod) {
           // is a custom module?
           var currentFile = data.currentFile || resolveProjectPath(server, node.sourceFile.name);
-          mod = resolveModule(server, name, currentFile);        
+          if (currentFile) {
+            var relative = /^\.{0,2}\//.test(name);
+            if (relative) name = resolvePath(currentFile, name);
+            mod = resolveModule(server, name, currentFile);
+          }          
         }
-        if (!(mod && mod.getType())) addMessage(argNodes[0], "Unknown module '" + name + "'", rule.severity);
+        if (!(mod && (mod.getFunctionType() || mod.getType()))) addMessage(argNodes[0], "Unknown module '" + argNodes[0].value + "'", rule.severity);
       }
     });    
   }


### PR DESCRIPTION
This PR gives the capability to validate the existing of module declared inside node require function with tern-lint https://github.com/angelozerr/tern-lint

Here a screenshot with CodeMirror : 

![ternnodelintwithcodemirror](https://cloud.githubusercontent.com/assets/1932211/5329320/914d7158-7da8-11e4-9692-3d6ca354db9b.png)

Here a screenshot with Eclipse  :

![ternnodelintwitheclipse](https://cloud.githubusercontent.com/assets/1932211/5329315/6bc3caae-7da8-11e4-86cc-76db76d20482.png)

I'm not sure that you will accept this PR since tern-lint is not included inside tern, but I think require module validation is an helpfull feature.

The basic idea is : 
- use !data and !lint  to tell to tern-lint that require function type must use a custom lint function called nodeRequire_lint

``` json
require: {
        "!type": "fn(id: string) -> !custom:nodeRequire",
        "!data": {
          "!lint": "nodeRequire_lint",
        },
```
- define and register the custom lint nodeRequire_lint : 

``` javascript
  if (tern.registerLint) {
    tern.registerLint("nodeRequire_lint", function(node, addMessage, getRule) {
      var rule = getRule("UnknownModule");
      if (!rule) return;
      var cx = infer.cx(), server = cx.parent, data = server._node;
      var argNodes = node.arguments;
      if (argNodes && argNodes.length && argNodes[0].type == "Literal" || typeof argNodes[0].value == "string") {
        var name = argNodes[0].value, locals = cx.definitions.node;
        // is a local module (fs, etc)
        var mod = locals[name];                  
        if (!mod) {
          // is a custom module?
          var currentFile = data.currentFile || resolveProjectPath(server, node.sourceFile.name);
          mod = resolveModule(server, name, currentFile);        
        }
        if (!(mod && mod.getType())) addMessage(argNodes[0], "Unknown module '" + name + "'", rule.severity);
      }
    });    
  }
```

Hope you will accept this code, otherwise I will set this code in a new tern plugin like node-lint.js (it will be very shame). In this case, do you know how I could link a custom lint function to the require function type with clean mean?

The second problem that I will have if you don't accept this PR, is that I will must redefine resolveModule in the new node-lint.js file.

Hope you will accept this PR.
