### PR TITLE
Inject function type for tern.registerFunction handler

### DIFF
--- a/lib/def.js
+++ b/lib/def.js
@@ -169,7 +169,7 @@
   function addEffect(fn, handler, replaceRet) {
     var oldCmp = fn.computeRet, rv = fn.retval;
     fn.computeRet = function(self, args, argNodes) {
-      var handled = handler(self, args, argNodes);
+      var handled = handler(self, args, argNodes, fn.getType());
       var old = oldCmp ? oldCmp(self, args, argNodes) : rv;
       return replaceRet ? handled : old;
     };


### PR DESCRIPTION
This PR inject function type to the tern.registerFunction handler. The function type can be usefull for instance to retrieve argument types of the function.

Today we can do that with self, but we need hard coded the function name in the handler : 

``` javascript
infer.registerFunction("a", function(self, args, argNodes) {
  var fnType = self.hasProp("MyFunction").getType();
  fnType . // use function type
```

with this PR, fnType can be retrieved directly in the handler without hard coding the function name.

``` javascript
infer.registerFunction("a", function(self, args, argNodes, fnType ) {
    fnType . // use function type
```
