### PR TITLE
Support "square bracket around @param name inside JSDoc for optional params" notation

### DIFF
--- a/plugin/doc_comment.js
+++ b/plugin/doc_comment.js
@@ -280,7 +280,7 @@
         case "type":
           type = parsed; break;
         case "param": case "arg": case "argument":
-            var name = m[2].slice(parsed.end).match(/^\s*(\[?\s*)([^\]\s]+)\s*(\]?).*/);
+            var name = m[2].slice(parsed.end).match(/^\s*(\[?)\s*([^\]\s]+)\s*(\]?).*/);
             if (!name) continue;         
             var argname = name[2] + (parsed.isOptional || (name[1] === '[' && name[3] === ']') ? "?" : "");
           (args || (args = Object.create(null)))[argname] = parsed;


### PR DESCRIPTION
Implements #445
