### PR TITLE
Fields for fs:Stats in node plugin have wrong type

### DIFF
--- a/plugin/node.js
+++ b/plugin/node.js
@@ -1965,9 +1965,9 @@
             size: "number",
             blksize: "number",
             blocks: "number",
-            atime: "Date",
-            mtime: "Date",
-            ctime: "Date"
+            atime: "+Date",
+            mtime: "+Date",
+            ctime: "+Date"
           },
           "!url": "http://nodejs.org/api/fs.html#fs_class_fs_stats",
           "!doc": "Objects returned from fs.stat(), fs.lstat() and fs.fstat() and their synchronous counterparts are of this type."


### PR DESCRIPTION
I suppose that the types should have a + prefix, although I merely made it work in 'tern.java'. I have not found how it is used throughout tern yet.
If this part is generated by `condense`, perhaps I should look for a bug there?
