### PR TITLE
Use hasProp inside findExprType

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -770,11 +770,11 @@
       var name = objProp.key.name;
       var fromCx = ensureObj(infer.typeFromContext(file.ast, expr));
       if (fromCx && fromCx.hasProp(name)) {
-        type = fromCx.hasProp[name];
+        type = fromCx.hasProp(name);
       } else {
         var fromLocal = ensureObj(type);
         if (fromLocal && fromLocal.hasProp(name))
-          type = fromLocal.hasProp[name];
+          type = fromLocal.hasProp(name);
       }
     }
     return type;


### PR DESCRIPTION
Type fromCx must be retrieved with hasProp and not props in case when properties comes from a prototype otherwise type can be null.
