### PR TITLE
Added a method that allows extending existing query types

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -66,6 +66,25 @@
 
   exports.defineQueryType = function(name, desc) { queryTypes[name] = desc; };
 
+  exports.extendQueryType = function(name, desc) {
+    var existingDesc = queryTypes[name];
+    if(!existingDesc)
+      return exports.defineQueryType(name, desc);
+
+    var extensionRun  = desc.run;
+
+    for(var key in existingDesc){
+      if(existingDesc.hasOwnProperty(key) && !desc.hasOwnProperty(key)){
+         desc[key] = existingDesc[key];
+      }
+    }
+    desc.run = function(srv, query, file){
+      return extensionRun(srv, query, file, existingDesc.run);
+    };
+
+    queryTypes[name] = desc;
+  };
+
   function File(name, parent) {
     this.name = name;
     this.parent = parent;


### PR DESCRIPTION
This pull requests add a mechanism to extend existing query types supported by Tern.  It defines a new method which can be used to register a function that is called instead of the default one for any of the existing query types.  This function also receives the default implementation as a parameter and hence the user can build on top of default implementation.  This is in response to the issue https://github.com/marijnh/tern/issues/481