### PR TITLE
Add some more console functions to browser.json

### DIFF
--- a/defs/browser.json
+++ b/defs/browser.json
@@ -2631,27 +2631,72 @@
     "!doc": "Selection is the class of the object returned by window.getSelection() and other methods. It represents the text selection in the greater page, possibly spanning multiple elements, when the user drags over static text and other parts of the page. For information about text selection in an individual text editing element."
   },
   "console": {
+    "assert": {
+      "!type": "fn(assertion: bool, text: string)",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.assert",
+      "!doc": "Writes an error message to the console if the assertion is false."
+    },
+    "count": {
+      "!type": "fn(label?: string)",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.count",
+      "!doc": "Logs the number of times that this particular call to count() has been called."
+    },
+    "dir": {
+      "!type": "fn(object: ?)",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.dir",
+      "!doc": "Displays an interactive list of the properties of the specified JavaScript object."
+    },
     "error": {
       "!type": "fn(text: string)",
-      "!url": "https://developer.mozilla.org/en/docs/DOM/console.error",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.error",
       "!doc": "Outputs an error message to the Web Console."
+    },
+    "group": {
+      "!type": "fn()",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.group",
+      "!doc": "Creates a new inline group in the Web Console log."
+    },
+    "groupCollapsed": {
+      "!type": "fn()",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.groupCollapsed",
+      "!doc": "Creates a new inline group in the Web Console log."
+    },
+    "groupEnd": {
+      "!type": "fn()",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.groupEnd",
+      "!doc": "Exits the current inline group in the Web Console."
     },
     "info": {
       "!type": "fn(text: string)",
-      "!url": "https://developer.mozilla.org/en/docs/DOM/console.info",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.info",
       "!doc": "Outputs an informational message to the Web Console."
     },
     "log": {
       "!type": "fn(text: string)",
-      "!url": "https://developer.mozilla.org/en/docs/DOM/console.log",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.log",
       "!doc": "Outputs a message to the Web Console."
+    },
+    "time": {
+      "!type": "fn(timerName: string)",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.time",
+      "!doc": "Starts a timer you can use to track how long an operation takes."
+    },
+    "timeEnd": {
+      "!type": "fn(timerName: string)",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.timeEnd",
+      "!doc": "Stops a timer that was previously started by calling console.time()."
+    },
+    "trace": {
+      "!type": "fn()",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.trace",
+      "!doc": "Outputs a stack trace to the Web Console."
     },
     "warn": {
       "!type": "fn(text: string)",
-      "!url": "https://developer.mozilla.org/en/docs/DOM/console.warn",
+      "!url": "https://developer.mozilla.org/en/docs/Web/API/Console.warn",
       "!doc": "Outputs a warning message to the Web Console."
     },
-    "!url": "https://developer.mozilla.org/en/docs/DOM/console",
+    "!url": "https://developer.mozilla.org/en/docs/Web/API/Console",
     "!doc": "The console object provides access to the browser's debugging console. The specifics of how it works vary from browser to browser, but there is a de facto set of features that are typically provided."
   },
   "top": {


### PR DESCRIPTION
Taken from https://developer.mozilla.org/en-US/docs/Web/API/Console.
I've also updated the URLs of the existing functions (they all pointed to a redirect) and sorted them alphabetically.

