### PR TITLE
Fix an incorrect sourcing of the original file.

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -873,7 +873,7 @@
       var spanFile = span.node.sourceFile || srv.findFile(span.origin);
       var start = outputPos(query, spanFile, span.node.start), end = outputPos(query, spanFile, span.node.end);
       result.start = start; result.end = end;
-      result.file = span.origin;
+      result.file = spanFile.name;
       var cxStart = Math.max(0, span.node.start - 50);
       result.contextOffset = span.node.start - cxStart;
       result.context = spanFile.text.slice(cxStart, cxStart + 50);


### PR DESCRIPTION
This looks like a typo, in a block where we acquired start and end positions
based on the spanFile, we return the span.origin as the name of the file.
span.origin and spanFile.name can differ.

I don't understand this part of the code 100%, but I noticed a bug working with my code and running the `definition` command. And then I debugged it down to this statement.