### PR TITLE
Basic support for JSDoc @param {function}

### DIFF
--- a/plugin/doc_comment.js
+++ b/plugin/doc_comment.js
@@ -304,6 +304,9 @@
           if (str.charAt(pos++) != ">") return null;
           val.type.propagate(type.defProp("<i>"));
         }
+      } else if(/^function$/i.test(word)) {
+        // TODO : support for args parameter types + return types + "this"
+        type = new infer.Fn(null, infer.ANull, [], [], infer.ANull);
       } else {
         while (str.charCodeAt(pos) == 46 ||
                acorn.isIdentifierChar(str.charCodeAt(pos))) ++pos;


### PR DESCRIPTION
This PR provides a basic support for JSDoc {function} : 

```javascript
/**
 * @param {function} fn
**/
function test(fn) {
}
```

It should be improved to :

 * support args of function : 

```javascript
/**
 * @param {function(number)} fn
**/
function test(fn) {
}
```

 * support this of function : 

```javascript
/**
 * @param {function(this:number)} fn
**/
function test(fn) {
  this. // here Ctrl+Spaces shows methods of number.
}
```

In other words it should be cool to have the same features than JetBrains. See http://blog.jetbrains.com/webide/2012/10/validating-javascript-code-with-jsdoc-types-annotations/