### PR TITLE
Set custom metaData to the tern file

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -111,10 +111,10 @@
     this.reset();
   };
   Server.prototype = signal.mixin({
-    addFile: function(name, /*optional*/ text, parent) {
+    addFile: function(name, /*optional*/ text, parent, /*optional*/ metaData) {
       // Don't crash when sloppy plugins pass non-existent parent ids
       if (parent && !(parent in this.fileMap)) parent = null;
-      ensureFile(this, name, parent, text);
+      ensureFile(this, name, parent, text, metaData);
     },
     delFile: function(name) {
       var file = this.findFile(name);
@@ -185,7 +185,7 @@
       if (file.type == "delete")
         srv.delFile(file.name);
       else
-        ensureFile(srv, file.name, null, file.type == "full" ? file.text : null);
+        ensureFile(srv, file.name, null, file.type == "full" ? file.text : null, file.metaData);
     }
 
     var timeBudget = typeof doc.timeout == "number" ? [doc.timeout] : null;
@@ -230,7 +230,7 @@
     return file;
   }
 
-  function ensureFile(srv, name, parent, text) {
+  function ensureFile(srv, name, parent, text, metaData) {
     var known = srv.findFile(name);
     if (known) {
       if (text != null) {
@@ -248,6 +248,7 @@
     }
 
     var file = new File(name, parent);
+    if (metaData) file.metaData = metaData;
     srv.files.push(file);
     srv.fileMap[name] = file;
     if (text != null) {


### PR DESCRIPTION
This PR gives the capability to set custom metaData to the tern file when tern file is send to teh server by the client.

For instance tern client can set metaData to {"html": true} and this meta data can be used by a tern plugin to know if the file is an html file.