### PR TITLE
Support @class and @constructor jsdoc attributes

### DIFF
--- a/test/cases/jsdoc.js
+++ b/test/cases/jsdoc.js
@@ -22,14 +22,19 @@ var abc = function() {
   this; //: Date
 };
 
+/** @this Abc */
+var Abc = function() {
+  this; //: Abc
+};
+
 /** @class */
-var abcCls = function() {
-  this; //: fn()
+var AbcCls = function() {
+  this; //: AbcCls
 };
 
 /** @constructor */
-var abcCtor = function() {
-  this; //: fn()
+var AbcCtor = function() {
+  this; //: AbcCtor
 };
 
 /**

--- a/test/cases/jsdoc.js
+++ b/test/cases/jsdoc.js
@@ -22,6 +22,16 @@ var abc = function() {
   this; //: Date
 };
 
+/** @class */
+var abcCls = function() {
+  this; //: fn()
+};
+
+/** @constructor */
+var abcCtor = function() {
+  this; //: fn()
+};
+
 /**
  * This is also a function
  * @returns {string}


### PR DESCRIPTION
http://usejsdoc.org/tags-class.html

`@class` and `@constructor` behave the same as `@this`, but unlike `@this`, which needs an explicit type name, these two attributes define the 'this' parameter as the current function without having to implicitly name it.

Only the default syntax without explicit type/name is supported.