### PR TITLE
New deleteDefsByName API for Tern.Server

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -843,6 +843,17 @@ Otherwise, they are added at the back.
 </p>
 </dd>
 <dt>
+<a id="tern.Server.deleteDefsByName"></a> <code>deleteDefsByName(name: string)</code>
+</dt>
+<dd>
+<p>
+Delete
+a set of <a href="#typedef">type definitions</a> from the server, by providing the name, taken from
+<code>defs[!name]</code> property from the definitions. If that property is not available in the 
+current type definitions, it can't be removed.
+</p>
+</dd>
+<dt>
 <a id="tern.Server.loadPlugin"></a> <code>loadPlugin(name: string, options?: object)</code>
 </dt>
 <dd>

--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -408,6 +408,11 @@ a set of <<typedef,type definitions>> to the server. If `atFront` is
 true, they will be added before all other existing definitions.
 Otherwise, they are added at the back.
 
+[[tern.Server.deleteDefsByName]] `deleteDefsByName(name: string)`:: Delete
+a set of <<typedef,type definitions>> from the server, by providing the name, 
+taken from `defs[!name]` property from the definitions. If that property is not 
+available in the current type definitions, it can't be removed.
+
 [[tern.Server.loadPlugin]] `loadPlugin(name: string, options?: object)`::
 Load a <<plugins,server plugin>> (or don't do anything, if the plugin
 is already loaded).

--- a/lib/tern.js
+++ b/lib/tern.js
@@ -192,6 +192,23 @@
       if (this.cx) this.reset()
     },
 
+    deleteDefsByName: function(name) {
+      var defsIndex;
+
+      this.defs.some(function (defs, index) {
+        var isDef = (name === defs["!name"]);
+        if (isDef) defsIndex = index;
+
+        return isDef;
+      });
+
+      if (defsIndex !== undefined) {
+        this.defs.splice(defsIndex, 1);
+
+        if (this.cx) this.reset();
+      }
+    },
+
     loadPlugin: function(name, options) {
       if (arguments.length == 1) options = this.options.plugins[name] || true
       if (name in this.plugins || !(name in plugins) || !options) return


### PR DESCRIPTION
Hi @marijnh, this PR is a proposal for a new API to Tern.Server. 
I'm using tern to provide hints, and I have an scenario where I dynamically generate tern definitions for specific APIs, and I use `Tern.Server.addDefs` API to update the current Tern.Server instance definitions. Sometimes, those APIs are removed in my application, and I need to tell tern server instance that those definitions should not be used anymore. To do that, today, I have a couple of alternatives:

1. Keep in cache the current configuration for the tern server, create a new instance of `Tern.Server` and pass the cached configuration.
2. Use the implementation proposed in this PR in my implementation that consumes the `Tern.Server` instance APIs.

Since this implementation for removing added definitions could be useful for other applications that uses Tern, I proposed in this PR to extend `Tern.Server` APIs by adding this one.

I have a couple of alternatives on how to implement it. But this one doesn't require any extra change in how defs are handled by tern and def modules.

Thanks!