### PR TITLE
Store the reference httpServer in tern server instance

### DIFF
--- a/bin/tern
+++ b/bin/tern
@@ -208,6 +208,7 @@ var httpServer = require("http").createServer(function(req, resp) {
     else respondSimple(resp, 400, "Missing query document");
   }
 });
+server.httpServer = httpServer;
 httpServer.listen(port, host, function() {
   var port = httpServer.address().port;
   if (!noPortFile) {


### PR DESCRIPTION
This PR gives the capability to retrieve by a tern plugin the httpServer from the server server instance. See discussion at https://github.com/ternjs/tern/issues/679

In my case I need that to use tern with WebSocket to send to the client when Angular modules changes. I'm developping a generic project which provides a new method to the tern server sendToClient in https://github.com/angelozerr/tern-push