### PR TITLE
[RFC] Allow absolute paths to be used in query

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -129,7 +129,7 @@
     addFile: function(name, /*optional*/ text, parent) {
       // Don't crash when sloppy plugins pass non-existent parent ids
       if (parent && !(parent in this.fileMap)) parent = null;
-      if (!(name in this.fileMap))
+      if (!(this.normalizeFilename(name) in this.fileMap))
         name = this.normalizeFilename(name)
       ensureFile(this, name, parent, text);
     },
@@ -138,7 +138,7 @@
       if (file) {
         this.needsPurge.push(file.name);
         this.files.splice(this.files.indexOf(file), 1);
-        delete this.fileMap[name];
+        delete this.fileMap[this.normalizeFilename(name)];
       }
     },
     reset: function() {
@@ -168,7 +168,7 @@
     },
 
     findFile: function(name) {
-      return this.fileMap[name];
+      return this.fileMap[this.normalizeFilename(name)];
     },
 
     flush: function(c) {
@@ -302,7 +302,7 @@
 
     var file = new File(name, parent);
     srv.files.push(file);
-    srv.fileMap[name] = file;
+    srv.fileMap[srv.normalizeFilename(name)] = file;
     if (text != null) {
       updateText(file, text, srv);
     } else if (srv.options.async) {


### PR DESCRIPTION
This relates to #690 where a more complete use-case example can be seen.

We're trying to integrate tern.js with YouCompleteMe, a Vim completion plugin used by tens of thousands of users.

The primary use-case for this is that users of the API don't (or, shouldn't)
need to know anything about `.tern-project` and tern's internal project
structure. The simplest thing for editors to do is to just supply the abosolute
path to dirty buffers (in the files section of the query) and have tern
determine if/that they are also included by things like require.js.

A typical example might be a file containing `require('lib/test.js', ...)` and
an API user supplying an unsaved version of 'lib/test.js' with its absolute path
as the filename.

Submitting this in the hope of getting some feedback on the approach.

Things TODO:
* [ ] decide if always storing relative paths is correct, rather than always storing absolute paths (which seems simpler, and less brittle)
* [ ] find a way of testing this automatically (I've started [some work](https://github.com/puremourning/tern/commit/1e190ec4622d37752253fa614f257246988ae8a5) on documenting the test suite and learning how it fits together)
* [ ] anything else you might think is required.