### PR TITLE
Fix flattenPath to correctly process parent (..) dir.

### DIFF
--- a/plugin/requirejs.js
+++ b/plugin/requirejs.js
@@ -12,7 +12,7 @@
     var parts = path.split("/");
     for (var i = 0; i < parts.length; ++i) {
       if (parts[i] == "." || !parts[i]) parts.splice(i--, 1);
-      else if (i && parts[i] == "..") parts.splice(i-- - 1, 2);
+      else if (i && parts[i] == "..") { parts.splice(i - 1, 2); i -= 2; }
     }
     return parts.join("/");
   }


### PR DESCRIPTION
Currently, flattenPath('/a/b/c/../../d/e/f') returns 'a/b/../d/e/f'.
This patch makes it return 'a/d/e/f'.