### PR TITLE
Fix default configuration detection on Windows.

### DIFF
--- a/bin/tern
+++ b/bin/tern
@@ -51,7 +51,7 @@ var defaultConfig = {
   ecmaVersion: 6,
   dependencyBudget: tern.defaultOptions.dependencyBudget
 };
-var homeDir = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
+var homeDir = process.env.HOME || process.env.USERPROFILE;
 if (homeDir && fs.existsSync(path.resolve(homeDir, ".tern-config")))
   defaultConfig = readProjectFile(path.resolve(homeDir, ".tern-config"));
 


### PR DESCRIPTION
The configuration file was never found because HOMEPATH doesn't return a full path on Windows (missing drive letter).

HOME works for both OS X and Linux, USERPROFILE works on Windows.