### PR TITLE
[emacs mode] Fix tern-project-dir for remote host

### DIFF
--- a/emacs/tern.el
+++ b/emacs/tern.el
@@ -53,7 +53,7 @@
   (or tern-project-dir
       (and (not (buffer-file-name)) (setf tern-project-dir ""))
       (let ((project-dir (file-name-directory (buffer-file-name))))
-        (cl-loop for cur = project-dir then (let ((shorter (file-name-directory (substring cur 0 (1- (length cur))))))
+        (cl-loop for cur = project-dir then (let ((shorter (file-name-directory (directory-file-name cur))))
                                               (and (< (length shorter) (length cur)) shorter))
                  while cur do
                  (when (file-exists-p (expand-file-name ".tern-project" cur))


### PR DESCRIPTION
This could fix #737.

Here is simple confirmation with org-mode (Sorry if it is unreadable).
This shows `original` and `fixed` code results for local and remote directories.

As in `original(project-dir="/plink:host:/home/foo")` below, the original `tern-project-dir` checks existence of "/plink:.tern-project", which causes "Host name must not match method" error.

```
#+NAME: original
#+HEADER: var project-dir
#+BEGIN_SRC emacs-lisp
    (let (results)
      (cl-loop for cur = project-dir then (let ((shorter (file-name-directory (substring cur 0 (1- (length cur))))))
                                    (and (< (length shorter) (length cur)) shorter))
               while cur do
               (push cur results))
      results)

#+END_SRC

#+NAME: fixed
#+HEADER: var project-dir
#+BEGIN_SRC emacs-lisp
    (let (results)
      (cl-loop for cur = project-dir then (let ((shorter (file-name-directory (directory-file-name cur))))
                                    (and (< (length shorter) (length cur)) shorter))
               while cur do
               (push cur results))
      results)

#+END_SRC

#+CALL: original(project-dir="/home/foo") :exports results
#+RESULTS:
| / | /home/ | /home/foo |

#+CALL: original(project-dir="/plink:host:/home/foo") :exports results
#+RESULTS:
| / | /plink: | /plink:host: | /plink:host:/ | /plink:host:/home/ | /plink:host:/home/foo |

#+CALL: fixed(project-dir="/home/foo") :exports results
#+RESULTS:
| / | /home/ | /home/foo |

#+CALL: fixed(project-dir="/plink:host:/home/foo") :exports results
#+RESULTS:
| /plink:host:/ | /plink:host:/home/ | /plink:host:/home/foo |
```
