### PR TITLE
Resolve plugin from the current working directory

### DIFF
--- a/bin/tern
+++ b/bin/tern
@@ -118,10 +118,14 @@ function loadPlugins(projectDir, config) {
     if (!val) continue;
     var found = findFile(plugin + ".js", projectDir, path.resolve(distDir, "plugin"));
     if (!found) {
-      found = resolveCwd("tern-" + plugin);
-      if (!found) {
-        process.stderr.write("Failed to find plugin " + plugin + ".\n");
-        continue;
+      try {
+        found = require.resolve("tern-" + plugin);
+      } catch (e) {
+        found = resolveCwd("tern-" + plugin);
+        if (!found) {
+          process.stderr.write("Failed to find plugin " + plugin + ".\n");
+          continue;
+        }
       }
     }
     var mod = require(found);

--- a/bin/tern
+++ b/bin/tern
@@ -8,6 +8,7 @@
 var tern = require("../lib/tern");
 var fs = require("fs"), path = require("path"), url = require("url");
 var glob = require("glob"), minimatch = require("minimatch");
+var resolveCwd = require("resolve-cwd");
 
 var projectFileName = ".tern-project", portFileName = ".tern-port";
 var maxIdleTime = 6e4 * 5; // Shut down after five minutes of inactivity
@@ -117,9 +118,8 @@ function loadPlugins(projectDir, config) {
     if (!val) continue;
     var found = findFile(plugin + ".js", projectDir, path.resolve(distDir, "plugin"));
     if (!found) {
-      try {
-        found = require.resolve("tern-" + plugin);
-      } catch (e) {
+      found = resolveCwd("tern-" + plugin);
+      if (!found) {
         process.stderr.write("Failed to find plugin " + plugin + ".\n");
         continue;
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "acorn": "^2.7.0",
     "enhanced-resolve": "^0.9.1",
     "glob": "3",
-    "minimatch": "0.2"
+    "minimatch": "0.2",
+    "resolve-cwd": "1.0.0"
   },
   "devDependencies": {
     "codemirror": "git://github.com/codemirror/CodeMirror.git"


### PR DESCRIPTION
While trying to test a tern plugin I'm writing, I encountered this error
`Failed to find plugin ...`
By using the [resolve-cwd](https://github.com/sindresorhus/resolve-cwd) module, this now works as expected, meaning I
can include my tern plugin in a given project, launch tern from the
project root directory, and make it work :smirk: