### PR TITLE
Catch scope

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -924,11 +924,12 @@
 
   // SCOPES
 
-  var Scope = exports.Scope = function(prev, originNode, isBlock) {
+  var Scope = exports.Scope = function(prev, originNode, isBlock, isCatch) {
     Obj.call(this, prev || true);
     this.prev = prev;
     this.originNode = originNode
     this.isBlock = !!isBlock
+    this.isCatch = !!isCatch
   };
   Scope.prototype = extend(Obj.prototype, {
     constructor: Scope,
@@ -942,7 +943,7 @@
   });
 
   function functionScope(scope) {
-    while (scope.isBlock) scope = scope.prev
+    while (scope.isBlock || scope.isCatch) scope = scope.prev
     return scope
   }
 
@@ -1120,13 +1121,14 @@
     TryStatement: function(node, scope, c) {
       c(node.block, scope, "Statement");
       if (node.handler) {
+        var inner = node.handler.scope = new Scope(scope, node.handler, false, true);
         if (node.handler.param.type == "Identifier") {
-          var v = addVar(scope, node.handler.param);
-          c(node.handler.body, scope, "Statement");
+          var v = addVar(inner, node.handler.param);
+          c(node.handler.body, inner, "Statement");
           var e5 = cx.definitions.ecma5;
           if (e5 && v.isEmpty()) getInstance(e5["Error.prototype"]).propagate(v, WG_CATCH_ERROR);
         } else {
-          c(node.handler.param, patternScopes(scope), "Pattern")
+          c(node.handler.param, patternScopes(inner), "Pattern")
         }
       }
       if (node.finalizer) c(node.finalizer, scope, "Statement");

--- a/lib/infer.js
+++ b/lib/infer.js
@@ -1118,20 +1118,16 @@
         scope = node.scope = new Scope(scope, node, true)
       walk.base.BlockStatement(node, scope, c)
     },
-    TryStatement: function(node, scope, c) {
-      c(node.block, scope, "Statement");
-      if (node.handler) {
-        var inner = node.handler.scope = new Scope(scope, node.handler, false, true);
-        if (node.handler.param.type == "Identifier") {
-          var v = addVar(inner, node.handler.param);
-          c(node.handler.body, inner, "Statement");
-          var e5 = cx.definitions.ecma5;
-          if (e5 && v.isEmpty()) getInstance(e5["Error.prototype"]).propagate(v, WG_CATCH_ERROR);
-        } else {
-          c(node.handler.param, patternScopes(inner), "Pattern")
-        }
+    CatchClause: function(node, scope, c) {
+      scope = node.scope = new Scope(scope, node, false, true);
+      if (node.param.type == "Identifier") {
+        var v = addVar(scope, node.param);
+        c(node.body, scope, "Statement");
+        var e5 = cx.definitions.ecma5;
+        if (e5 && v.isEmpty()) getInstance(e5["Error.prototype"]).propagate(v, WG_CATCH_ERROR);
+      } else {
+        c(node.param, patternScopes(scope), "Pattern")
       }
-      if (node.finalizer) c(node.finalizer, scope, "Statement");
     },
     VariableDeclaration: function(node, scope, c) {
       var targetScope = node.kind == "var" ? functionScope(scope) : scope
@@ -1936,6 +1932,9 @@
   var searchVisitor = exports.searchVisitor = walk.make({
     Function: function(node, _st, c) {
       walk.base.Function(node, node.scope, c)
+    },
+    CatchClause: function(node, _st, c) {
+      walk.base.CatchClause(node, node.scope, c)
     },
     Property: function(node, st, c) {
       if (node.computed) c(node.key, st, "Expression");

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "sh -c './bin/test'"
   },
   "dependencies": {
-    "acorn": "^2.7.0",
+    "acorn": "^3.1.0",
     "enhanced-resolve": "^0.9.1",
     "glob": "3",
     "minimatch": "0.2",


### PR DESCRIPTION
These changes make it so the scope of the `catch` parameter appears in the scope hierarchy. Previously, the `catch` parameter was treated as if it were declared with `var`. Therefore, if there were multiple `catch` clauses with the same parameter name in the same scope, then attempts to find the definition of the second would lead back to the first.

One motivation for this change is to be able to properly locate the definition of the parameter. Another is so that I can write a plugin which does scope analysis and `catch` parameters can be handled correctly.

In order to walk `CatchClause`, I had to update to the latest Acorn. I am not sure if the major version bump is cause for concern, but maybe it is if your dependents are requiring your copy of `acorn`. If that worries you, maybe we can backport the `CatchClause` support to `v2.x`, or see if this could still be accomplished with `TryStatement`.