### PR TITLE
Fixes endless recursion when evaluating type

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -2040,7 +2040,10 @@
       }
     },
     ReturnStatement: function(_parent, node, get) {
-      var fnNode = walk.findNodeAround(node.sourceFile.ast, node.start, "Function");
+      // tweaking search position to avoid endless recursion 
+      // when looking for definition of key in fn ( return fn ( return object ) )
+      // see ternjs/tern#777
+      var fnNode = walk.findNodeAround(node.sourceFile.ast, node.start - 1, "Function");
       if (fnNode) {
         var fnType = fnNode.node.type != "FunctionDeclaration"
           ? get(fnNode.node, true).getFunctionType()


### PR DESCRIPTION
Fixes endless recursion when trying to evaluate object's key type when object is enclosed into two functions (#777).
Test case
```
function main() {
	return function next() {
		return {foo: 1};
	};
}
```
Problem happened because once we reached "next" function expression, `findNodeAround(.., "function")` returned the same expression causing infinite loop