### PR TITLE
All proposals shown inside string literal #780

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -713,6 +713,14 @@
     // expression or an object literal.
     if (exprAt) {
       var exprNode = exprAt.node;
+      if(exprNode.type === 'Literal' && typeof exprNode.value === 'string') {
+        //if one of the plug-ins has not handled in-literal completions, return none
+        return {
+        	 start: outputPos(query, file, wordStart),
+           end: outputPos(query, file, wordEnd),
+           completions: []
+        };
+      }
       if (exprNode.type == "MemberExpression" && exprNode.object.end < wordStart) {
         memberExpr = exprAt;
       } else if (isStringAround(exprNode, wordStart, wordEnd)) {


### PR DESCRIPTION
https://github.com/ternjs/tern/issues/780

If there are no loaded plugins that handle completions inside literals, we should return none.

Related Orion bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=492470