### PR TITLE
Add missing keywords when ecmaVersion = 6

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -653,6 +653,10 @@
   var jsKeywords = ("break do instanceof typeof case else new var " +
     "catch finally return void continue for switch while debugger " +
     "function this with default if throw delete in try").split(" ");
+  var jsKeywordsInES6 = ("break do in typeof case else instanceof " +
+    "var catch export new void class extends return while const finally " +
+    "super with continue for switch yield debugger function this default " +
+    "if throw delete import try let static").split(" ");
 
   var addCompletion = exports.addCompletion = function(query, completions, name, aval, depth) {
     var typeInfo = query.types || query.docs || query.urls || query.origins;
@@ -764,9 +768,17 @@
       hookname = "memberCompletion";
     } else {
       infer.forAllLocalsAt(file.ast, wordStart, file.scope, gather);
-      if (query.includeKeywords) jsKeywords.forEach(function(kw) {
-        gather(kw, null, 0, function(rec) { rec.isKeyword = true; });
-      });
+      if (query.includeKeywords) {
+        var jsKeywordsToInclude = jsKeywords;
+        switch (srv.options.ecmaVersion) {
+          case 6:
+            jsKeywordsToInclude = jsKeywordsInES6;
+            break;
+        }
+        jsKeywordsToInclude.forEach(function(kw) {
+          gather(kw, null, 0, function(rec) { rec.isKeyword = true; });
+        });
+      };
       hookname = "variableCompletion";
     }
     srv.signal(hookname, file, wordStart, wordEnd, gather)


### PR DESCRIPTION
Add missing keyword autocompletion for ES6, e.g. let const static etc.

Only works when ecmaVersion = 6
nothing has changed in ES5

Fix #784