### PR TITLE
Added null check in the registered "getSymbol" function

### DIFF
--- a/lib/def.js
+++ b/lib/def.js
@@ -665,7 +665,7 @@
   })
 
   infer.registerFunction("getSymbol", function(_self, _args, argNodes) {
-    if (argNodes.length && argNodes[0].type == "Literal" && typeof argNodes[0].value == "string")
+    if (argNodes && argNodes.length && argNodes[0].type == "Literal" && typeof argNodes[0].value == "string")
       return infer.getSymbol(argNodes[0].value)
     else
       return infer.ANull


### PR DESCRIPTION
Sometimes `argNodes` may be `null` causing
```
"TypeError: Cannot read property 'length' of null
    at .../node_modules/tern/lib/def.js:668:17"
```
Added check to prevent this error