### PR TITLE
Proposals with same names but different origins can be ignored #797

### DIFF
--- a/lib/tern.js
+++ b/lib/tern.js
@@ -660,9 +660,14 @@
     var typeInfo = query.types || query.docs || query.urls || query.origins;
     var wrapAsObjs = typeInfo || query.depths;
 
-    for (var i = 0; i < completions.length; ++i) {
+    for (var i = 0, len = completions.length; i < len; i++) {
       var c = completions[i];
-      if ((wrapAsObjs ? c.name : c) == name) return;
+      if ((wrapAsObjs ? c.name : c) == name) {
+        if(query.origins && aval && c.origin !== aval.origin) {
+          continue;
+        }
+        return;
+      }
     }
     var rec = wrapAsObjs ? {name: name} : name;
     completions.push(rec);
@@ -761,8 +766,13 @@
 
       if (!completions.length && query.guess !== false && objType && objType.guessProperties)
         objType.guessProperties(function(p, o, d) {if (p != prop && p != "✖") gather(p, o, d);});
-      if (!completions.length && word.length >= 2 && query.guess !== false)
-        for (var prop in srv.cx.props) gather(prop, srv.cx.props[prop][0], 0);
+      if (!completions.length && word.length >= 2 && query.guess !== false) {
+        Object.keys(srv.cx.props).forEach(function(prop) {
+          srv.cx.props[prop].forEach(function(type) {
+    	      gather(prop, type, 0);	
+    	    });
+    	  });
+      }
       hookname = "memberCompletion";
     } else {
       infer.forAllLocalsAt(file.ast, wordStart, file.scope, gather);


### PR DESCRIPTION
Check all properties, not just the first, and check origins before
leaving out same-named properties
