### PR TITLE
support webpack.config.js for webpack plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "acorn": "^3.2.0",
-    "enhanced-resolve": "^0.9.1",
+    "enhanced-resolve": "^2.2.2",
     "glob": "3",
     "minimatch": "0.2",
     "resolve-from": "2.0.0"
@@ -24,6 +24,15 @@
     "codemirror": "git://github.com/codemirror/CodeMirror.git"
   },
   "blint": {
-    "allowedGlobals": ["tern", "acorn", "define", "clearTimeout", "setTimeout", "__dirname", "global", "process"]
+    "allowedGlobals": [
+      "tern",
+      "acorn",
+      "define",
+      "clearTimeout",
+      "setTimeout",
+      "__dirname",
+      "global",
+      "process"
+    ]
   }
 }

--- a/plugin/webpack.js
+++ b/plugin/webpack.js
@@ -11,7 +11,12 @@ var path = require("path");
 var ResolverFactory = require("enhanced-resolve").ResolverFactory;
 var SyncNodeJsInputFileSystem = require("enhanced-resolve/lib/SyncNodeJsInputFileSystem");
 
-var file = process.cwd() + '/webpack.config.js'
+var file
+if (process.argv[1] && /test$/.test(process.argv[1])) {
+ file = path.resolve(__dirname, '../test/cases/webpack/webpack.config.js')
+} else {
+ file = path.resolve('./webpack.config.js')
+}
 var resolveConfig = fs.existsSync(file) ? require(file).resolve : null
 
 var config = {

--- a/plugin/webpack.js
+++ b/plugin/webpack.js
@@ -4,21 +4,39 @@ if (typeof exports != "object" || typeof module != "object")
 var infer = require("../lib/infer");
 var tern = require("../lib/tern");
 require("./commonjs");
+require("./es_modules");
 
+var fs = require('fs');
 var path = require("path");
-var req = require("enhanced-resolve");
-var DirectoryDescriptionFileFieldAliasPlugin = require("enhanced-resolve/lib/DirectoryDescriptionFileFieldAliasPlugin");
+var ResolverFactory = require("enhanced-resolve").ResolverFactory;
+var SyncNodeJsInputFileSystem = require("enhanced-resolve/lib/SyncNodeJsInputFileSystem");
 
-var resolver = new req.Resolver(new req.SyncNodeJsInputFileSystem());
-resolver.apply(
-  new DirectoryDescriptionFileFieldAliasPlugin("package.json", "browser"),
-  new req.ModulesInDirectoriesPlugin("node", ["node_modules"]),
-  new req.ModuleAsFilePlugin("node"),
-  new req.ModuleAsDirectoryPlugin("node"),
-  new req.DirectoryDescriptionFilePlugin("package.json", ["main", "browser"]),
-  new req.DirectoryDefaultFilePlugin(["index"]),
-  new req.FileAppendPlugin(["", ".js"])
-);
+var file = process.cwd() + '/webpack.config.js'
+var resolveConfig = fs.existsSync(file) ? require(file).resolve : null
+
+var config = {
+  unsafeCache: true,
+  modules: ["node_modules"],
+  extensions: [".js", ".jsx", ".json"],
+  aliasFields: ["browser"],
+  mainFields: ["browser", "web", "browserify", "main"],
+  fileSystem: new SyncNodeJsInputFileSystem()
+}
+
+if (resolveConfig) {
+  Object.keys(resolveConfig).forEach(function (key) {
+    if (key === 'packageMains') {
+      config.mainFields = resolveConfig[key]
+    } else if (key === 'root') {
+      config.modules.unshift(resolveConfig[key])
+    } else {
+      config[key] = resolveConfig[key]
+    }
+  })
+}
+
+var resolver = ResolverFactory.createResolver(config);
+
 
 function resolve(name, parentFile) {
   var resolved = resolveToFile(name, parentFile)
@@ -26,16 +44,18 @@ function resolve(name, parentFile) {
 }
 
 function resolveToFile(name, parentFile) {
-  try {
     var projectDir = infer.cx().parent.projectDir;
     var fullParent = path.resolve(projectDir, parentFile);
-    return resolver.resolveSync(fullParent, name);
-  } catch(e) {
-    return '';
-  }
+    try {
+      return resolver.resolveSync({}, path.dirname(fullParent), name);
+    } catch(e) {
+      console.log(e.stack)
+      return ''
+    }
 }
 
 tern.registerPlugin("webpack", function(server) {
   server.loadPlugin("commonjs")
+  server.loadPlugin("es_modules")
   server.mod.modules.resolvers.push(resolve)
 })

--- a/test/cases/webpack/component/foo.js
+++ b/test/cases/webpack/component/foo.js
@@ -1,0 +1,1 @@
+module.exports = {index: true}

--- a/test/cases/webpack/main.js
+++ b/test/cases/webpack/main.js
@@ -3,3 +3,11 @@
 require("foo") //:: {browser: bool}
 
 require("foo/index") //:: {index: bool}
+
+require("./component/foo") //:: {index: bool}
+
+require("component/foo") //:: {index: bool}
+
+require("xyz") //:: {index: bool}
+
+require("esnext") //:: {default: {index: bool}}

--- a/test/cases/webpack/node_modules/esnext/index.js
+++ b/test/cases/webpack/node_modules/esnext/index.js
@@ -1,0 +1,1 @@
+export default {index: true}

--- a/test/cases/webpack/node_modules/esnext/package.json
+++ b/test/cases/webpack/node_modules/esnext/package.json
@@ -1,0 +1,3 @@
+{
+  "jsnext:main": "index.js"
+}

--- a/test/cases/webpack/node_modules/modu/index.js
+++ b/test/cases/webpack/node_modules/modu/index.js
@@ -1,0 +1,1 @@
+module.exports = { index: true}

--- a/test/cases/webpack/node_modules/modu/package.json
+++ b/test/cases/webpack/node_modules/modu/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.js"
+}

--- a/test/cases/webpack/node_modules/xyz/index.js
+++ b/test/cases/webpack/node_modules/xyz/index.js
@@ -1,0 +1,1 @@
+module.exports = {index: false}

--- a/test/cases/webpack/node_modules/xyz/package.json
+++ b/test/cases/webpack/node_modules/xyz/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.js"
+}

--- a/test/cases/webpack/webpack.config.js
+++ b/test/cases/webpack/webpack.config.js
@@ -1,0 +1,11 @@
+var path = require('path')
+
+module.exports = {
+  resolve: {
+    packageMains: ['jsnext:main', 'browser', 'browserify', 'main'],
+    root: __dirname,
+    alias: {
+      xyz: "modu"
+    }
+  }
+}


### PR DESCRIPTION
This PR use latest `enhanced-resolve` module, supports:
* Load `webpack.config.js` from the same folder
* Same default options as webpack itself.
* Configuration like `root` `alias` `packageMains ` etc.
* es6 `import` support by using `es_modules` plugin.