### PR TITLE
Add lookup_paths option to node_resolve plugin

### DIFF
--- a/plugin/node_resolve.js
+++ b/plugin/node_resolve.js
@@ -15,6 +15,7 @@
   function findDeclaredDeps() {}
 
   var resolveToFile
+  var projectPaths = [];
   if (require) (function() {
     var module_ = require("module"), path = require("path"), fs = require("fs")
 
@@ -27,7 +28,9 @@
 
       var parentModule = {
         id: fullParent,
-        paths: module_._nodeModulePaths(parentDir).concat(module_.globalPaths)
+        paths: module_._nodeModulePaths(parentDir)
+                      .concat(projectPaths)
+                      .concat(module_.globalPaths)
       }
       try {
         return module_._resolveFilename(name, parentModule)
@@ -74,7 +77,10 @@
     }
   })()
 
-  tern.registerPlugin("node_resolve", function(server) {
+  tern.registerPlugin("node_resolve", function(server, options) {
+    if (options && options.hasOwnProperty('lookup_paths')) {
+      projectPaths = options.lookup_paths;
+    }
     server.loadPlugin("commonjs")
     server.mod.modules.resolvers.push(resolve)
     findDeclaredDeps(server.projectDir, server.mod.modules.knownModules)


### PR DESCRIPTION
We use NODE_PATH env variable in our project, it contains several specific "libs" paths where we store all libraries. Inside the code we load them with short line `var lib = require('project/lib');`
Tern failed to find them because node_resolve plugin looks for files only in standard paths.

This patch adds ability to configure project specific paths for node_resolve plugin. For example .tern-project:

``` json
  {
    "libs": [
        "underscore"
    ],
    "plugins": {
        "node_resolve": {
            "lookup_paths": [
                "lib",
                "3rdparty/lib"
            ]
        },
        "node": {}
    }
  }
```

Works fine with tern_for_sublime.
