### PR TITLE
Fixes for Promise.resolve

### DIFF
--- a/defs/ecma6.json
+++ b/defs/ecma6.json
@@ -680,7 +680,7 @@
     },
     "reject": "Promise_reject",
     "resolve": {
-      "!type": "fn(value: ?) -> +Promise[:t=!0]",
+      "!type": "fn(value: ?) -> !custom:Promise_resolve",
       "!doc": "The Promise.resolve(value) method returns a Promise object that is resolved with the given value. If the value is a thenable (i.e. has a then method), the returned promise will 'follow' that thenable, adopting its eventual state; otherwise the returned promise will be fulfilled with the value.",
       "!url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve"
     },

--- a/lib/def.js
+++ b/lib/def.js
@@ -641,26 +641,14 @@
 
     if(args.length > 0) {
       var argument = args[0];
-      if(argument instanceof infer.AVal) {
-        // Wrap each possible type in a Promise, unless it is already a Promise.
-        // TODO: Are there cases other than AVal that we need to handle?
-        // TODO: Transfer weights as well?
-        var promiseValue = new infer.AVal;
-        argument.types.forEach(function(tp) {
-          if (tp.constructor == infer.Obj && tp.name == "Promise" && tp.hasProp(":t")) {
-            tp = tp.getProp(':t');
-          }
-          tp.propagate(promiseValue);
-        });
-        promiseValue.propagate(valProp);
-      } else {
-        // Plain type - wrap in a Promise.
-        argument.propagate(valProp);
-      }
+      var valArg = new infer.AVal;
+      valArg.propagate(valProp);
+      argument.propagate(new PromiseResolvesTo(valArg));
     }
 
     return self;
   });
+
 
   var PromiseResolvesTo = infer.constraint({
     construct: function(output) { this.output = output; },

--- a/lib/def.js
+++ b/lib/def.js
@@ -630,6 +630,38 @@
     return self;
   });
 
+  // Definition for Promise.resolve()
+  // The behavior is different for Promise and non-Promise arguments, so we
+  // need a custom definition to handle the different cases properly.
+  infer.registerFunction("Promise_resolve", function(_self, args, argNodes) {
+    var defs6 = infer.cx().definitions.ecma6
+    if (!defs6) return infer.ANull;
+    var self = new infer.Obj(defs6["Promise.prototype"]);
+    var valProp = self.defProp(":t", argNodes && argNodes[0]);
+
+    if(args.length > 0) {
+      var argument = args[0];
+      if(argument instanceof infer.AVal) {
+        // Wrap each possible type in a Promise, unless it is already a Promise.
+        // TODO: Are there cases other than AVal that we need to handle?
+        // TODO: Transfer weights as well?
+        var promiseValue = new infer.AVal;
+        argument.types.forEach(function(tp) {
+          if (tp.constructor == infer.Obj && tp.name == "Promise" && tp.hasProp(":t")) {
+            tp = tp.getProp(':t');
+          }
+          tp.propagate(promiseValue);
+        });
+        promiseValue.propagate(valProp);
+      } else {
+        // Plain type - wrap in a Promise.
+        argument.propagate(valProp);
+      }
+    }
+
+    return self;
+  });
+
   var PromiseResolvesTo = infer.constraint({
     construct: function(output) { this.output = output; },
     addType: function(tp) {

--- a/test/cases/promise.js
+++ b/test/cases/promise.js
@@ -26,3 +26,29 @@ p3.then(function(value) {
 }).then(function(value) {
   value; //: bool
 });
+
+var p4 = Promise.resolve(Promise.resolve(10));
+p4.then(function(value) {
+  value; //: number
+});
+
+var arg5 = 1 < 2 ? Promise.resolve(10) : 20;
+var p5 = Promise.resolve(arg5);
+p5.then(function(value) {
+  value; //: number
+});
+
+var p6 = Promise.resolve('t').then(function() {
+  return 1 < 2 ? Promise.resolve(10) : 20;
+}).then(function(value) {
+  value; //: number
+});
+
+var p7 = Promise.resolve().then(function() {
+  return 20;
+}).then(function(value) {
+  value; //: number
+});
+
+var p8 = Promise.resolve();
+//: Promise

--- a/test/cases/promise.js
+++ b/test/cases/promise.js
@@ -51,4 +51,35 @@ var p7 = Promise.resolve().then(function() {
 });
 
 var p8 = Promise.resolve();
-//: Promise
+p8 //: Promise
+
+function myResolve1(arg) {
+  return Promise.resolve(arg);
+}
+
+myResolve1('s') //:: {:t: string}
+
+function myResolve2(arg) {
+  return Promise.resolve(arg);
+}
+
+myResolve2('s') //:: {:t: string|number}
+myResolve2(4) //:: {:t: string|number}
+
+myResolve2('s').then(function(value) {
+  value; //: string|number
+})
+
+function myResolve3(arg7) {
+  return Promise.resolve(arg7);
+}
+
+myResolve3(Promise.resolve(4)).then(function(value) {
+  value; //: number
+});
+
+myResolve3(Promise.resolve(4)) //:: {:t: number}
+
+myResolve3(4).then(function(value) {
+  value; //: number
+});


### PR DESCRIPTION
Say you have `p = Promise.resolve('a string')`, then `p` is a `Promise<String>`. The issue here is that `Promise.resolve(p)` is inferred as `Promise<Promise<string>>`, where it should be `Promise<string>`.

These two cases specifically were broken (the other added cases are to check for potential issues in my implementation):

```js
var p4 = Promise.resolve(Promise.resolve(10));
p4.then(function(value) {
  value; //: number (was Promise<number>)
});

var arg5 = 1 < 2 ? Promise.resolve(10) : 20;
var p5 = Promise.resolve(arg5);
p5.then(function(value) {
  value; //: number (was Promise<number>|number)
});
```

This PR fixes these test cases, but I may be missing some other edge cases (see the TODOs in the code).

It's a fairly niche use-case, but can make a big difference when working with Promise-heavy code (especially with async/await, which I'm experimenting with now - see #814).

