### PR TITLE
documentation request does not work for ClassDeclarations #844

### DIFF
--- a/plugin/doc_comment.js
+++ b/plugin/doc_comment.js
@@ -37,6 +37,7 @@
       FunctionDeclaration: attachComments,
       MethodDefinition: attachComments,
       Property: attachComments,
+      ClassDeclaration: attachComments,
       AssignmentExpression: function(node) {
         if (node.operator == "=") attachComments(node);
       },
@@ -495,7 +496,7 @@
     } else if (node.type == "AssignmentExpression") {
       if (isFunExpr(node.right))
         fn = node.right.scope.fnType;
-    } else if (node.type == "CallExpression") {
+    } else if (node.type == "CallExpression" || node.type === "ClassDeclaration") {
     } else { // An object property
       if (isFunExpr(node.value)) fn = node.value.scope.fnType;
     }


### PR DESCRIPTION
We just have to make sure we attach the comments to the declaration node, and avoid running isFnExpr on the ClassDeclaration node