### PR TITLE
Add SourceLair to projects with built-in support for Tern

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are currently plugins available for [Emacs][emacs] (and Emacs
 [company-mode][cmode]), [Vim][vim], [Sublime Text][st], [Eclipse (and general Java API)][ec],
 [Light Table][lt], [Atom][atom], [TextMate][tm] and [gedit][gedit], and built-in support in
 [Brackets][brackets], [Edge Code][edge_code], [CodeLite](http://codelite.org/),
-and [vy](https://github.com/iogf/vy).
+[vy](https://github.com/iogf/vy), and [SourceLair][sourcelair].
 
 For further documentation, see the [project page][1] and the
 [manual][3]. To report issues, use the
@@ -38,3 +38,4 @@ and documentation, see the
 [edge_code]: http://html.adobe.com/edge/code
 [cmode]: https://github.com/proofit404/company-tern
 [tm]: https://github.com/fab1an/JavaScript-Tern-Completion.tmbundle
+[sourcelair]: https://www.sourcelair.com

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@ the <a href="doc/demo.html">browser</a>.</p>
   <li><a href="https://github.com/mortalapeman/LT-TernJS">Light Table</a>
   <li><a href="https://github.com/angelozerr/tern.java">Eclipse (and general Java API)</a>
   <li><a href="https://github.com/fab1an/JavaScript-Tern-Completion.tmbundle">TextMate</a>
+  <li><a href="https://www.sourcelair.com/">SourceLair</a> (built in to the base editor)
 </ul>
 
 <p>Follow the links to find instructions on how to install the


### PR DESCRIPTION
[SourceLair provides built-in support for Tern](https://www.sourcelair.com/blog/articles/98/javascript-autocomplete) in it's JavaScript auto-complete feature.

It would be great if it was featured in the editors supporting Tern.