### PR TITLE
Prevent iteration for <top> proto

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -656,11 +656,14 @@
         if (this.proto) this.proto.forAllProps(this);
       }
       this.onNewProp.push(c);
-      for (var o = this; o; o = o.proto) for (var prop in o.props) {
-        if (c.onProtoProp)
-          c.onProtoProp(prop, o.props[prop], o == this);
-        else
-          c(prop, o.props[prop], o == this);
+      for (var o = this; o; o = o.proto) {
+        if (o.name == '<top>') break
+        for (var prop in o.props) {
+          if (c.onProtoProp)
+            c.onProtoProp(prop, o.props[prop], o == this);
+          else
+            c(prop, o.props[prop], o == this);
+        }
       }
     },
     maybeUnregProtoPropHandler: function() {


### PR DESCRIPTION
I found that It would cost 100% CPU usage when iterate through the infer named `<top>`, since it would have lot's of props.

I run into this issue with a es6 file which have many `export` statements.

<img width="781" alt="screen shot 2016-12-04 at 4 25 41 pm" src="https://cloud.githubusercontent.com/assets/251450/20877521/584a3e4a-bb04-11e6-82d8-f6902f621c7d.png">
