### PR TITLE
Documentation of webpack plugin

### DIFF
--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -670,6 +670,37 @@ This plugin (`es_modules`) builds on top of the
 <<plugin_modules,`modules` plugin>> to support ECMAScript 6's `import`
 and `export` based module inclusion.
 
+[[plugin_webpack]]
+==== Webpack plugin ====
+
+This plugin (`"webpack"`) make use of `enhance-resolve` module from
+webpack https://webpack.github.io/, so it can understand the `resolve`
+field of `webpack.config.js` for file resolving.
+<<plugin_commonjs,`commonjs` plugin>> and
+<<plugin_es_modules,`es_modules` plugin>> plugin are loaded in the
+meanwhile for correct file reoslve, this also means you can still
+have `commonjs` and/or `es_modules` in your `.tern-project` file,
+but not necessary.
+
+You can use `configPath` option for resolve the config file of webpack
+like:
+
+[source,application/x-json]
+----
+{
+  "libs": [
+  ],
+  "plugins": {
+    "webpack": {
+      "configPath": "./lib/webpack.prod.js",
+    }
+  }
+}
+----
+
+`configPath` should be a file path relative to `.tern-project`, you
+can omit it if they're in the same folder.
+
 [[plugin_requirejs]]
 ==== RequireJS plugin ====
 


### PR DESCRIPTION
I can't use make to generate the manual.html file, looks like my source-highlight not configured correctly, and I don't know how to make it works.

```
source-highlight: missing feature: language inference requires input file
source-highlight: could not find a language definition for application/x-json
asciidoc: WARNING: manual.txt: line 504: filter non-zero exit code: source-highlight -f xhtml -s application/x-json: returned 1
asciidoc: WARNING: manual.txt: line 504: no output from filter: source-highlight -f xhtml -s application/x-json
```

I've noticed there're some break change in enhanced-resolve v3.0.0, I think it's better to wait for webpack use it instead of upgrade too early.