### PR TITLE
Remove NPM warning about minimatch RegExp DoS issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "acorn": "^3.2.0",
     "enhanced-resolve": "^2.2.2",
-    "glob": "3",
-    "minimatch": "0.2",
+    "glob": "^7.1.1",
+    "minimatch": "^3.0.3",
     "resolve-from": "2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update dependencies `glob` and `minimatch` to latest versions to avoid
warning about minimatch RegExp DoS issue:

    warning minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
    warning glob > minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

Advisory can be found here:

  https://nodesecurity.io/advisories/118

and the fix to `minimatch` issue itself:

  https://github.com/isaacs/minimatch/commit/6944abf9e0694bd22fd9dad293faa40c2bc8a955