### PR TITLE
Fix `Cannot read property 'prev' of null`

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -987,7 +987,7 @@
         var oldOrigin = cx.curOrigin;
         cx.curOrigin = fn.origin;
         var scope = node.scope
-        var scopeCopy = new Scope(scope.prev, scope.originNode);
+        var scopeCopy = new Scope((scope && scope.prev) || {}, scope.originNode);
         for (var v in scope.props) {
           var local = scopeCopy.defProp(v, scope.props[v].originNode);
           for (var i = 0; i < args.length; ++i) if (fn.argNames[i] == v && i < args.length)


### PR DESCRIPTION
Not sure if this is the correct way to do this, but it fixed the bug that I was seeing locally with auto-completion and all that.

Should be a fix for: #891 