### PR TITLE
Popup full documentation in a separate Emacs window

### DIFF
--- a/emacs/tern.el
+++ b/emacs/tern.el
@@ -12,6 +12,7 @@
 (require 'url)
 (require 'url-http)
 
+(defvar tern-docs-popup-buffer "*tern:docs*")
 (defvar tern-known-port nil)
 (defvar tern-server nil)
 (defvar tern-explicit-port nil)
@@ -21,6 +22,17 @@
 
 (defun tern-message (fmt &rest objects)
   (apply 'message fmt objects))
+
+(defun tern-popup-buffer (buffer-name text)
+  (pop-to-buffer
+   (with-current-buffer (get-buffer-create buffer-name)
+     (view-mode -1)
+     (setq buffer-read-only nil)
+     (erase-buffer)
+     (insert text)
+     (goto-char (point-min))
+     (view-mode +1)
+     (current-buffer))))
 
 (defun tern-req (port doc c)
   (let* ((url-mime-charset-string nil) ; Suppress huge, useless header
@@ -504,20 +516,20 @@ list of strings, giving the binary name and arguments.")
 (defvar tern-last-docs-url nil)
 (defun tern-get-docs ()
   (interactive)
-  (if (and tern-last-docs-url (eq last-command 'tern-get-docs))
-      (progn
-        (browse-url tern-last-docs-url)
-        (setf tern-last-docs-url nil))
-    (tern-run-query (lambda (data)
-                      (let ((url (cdr (assq 'url data))) (doc (cdr (assq 'doc data))))
+  (tern-run-query (lambda (data)
+                    (let ((url (cdr (assq 'url data))) (doc (cdr (assq 'doc data))))
+                      (if (and tern-last-docs-url (equal url tern-last-docs-url))
+                          (progn
+                            (setf tern-last-docs-url nil)
+                            (browse-url url))
                         (cond (doc
                                (setf tern-last-docs-url url)
-                               (tern-message doc))
+                               (tern-popup-buffer tern-docs-popup-buffer doc))
                               (url
                                (browse-url url))
-                              (t (tern-message "Not found")))))
-                    "documentation"
-                    (point))))
+                              (t (tern-message "Not found"))))))
+                    `((type . "documentation") (docFormat . "full"))
+                    (point)))
 
 ;; Connection management
 


### PR DESCRIPTION
I find this more useful than just showing the first line of the docs.