### PR TITLE
Allow for webpack resolve configs to be passed directly

### DIFF
--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -702,6 +702,23 @@ like:
 `configPath` should be a file path relative to `.tern-project`, you
 can omit it if they're in the same folder.
 
+You cal also pass the `"module"` and `"alias"` keys directly instead
+of passing the "configPath"
+
+[source,application/x-json]
+----
+{
+  "libs": [
+  ],
+  "plugins": {
+    "webpack": {
+      "alias": { "lib": "./src/lib" },
+      "modules": ["node_modules", "src"]
+    }
+  }
+}
+----
+
 [[plugin_requirejs]]
 ==== RequireJS plugin ====
 

--- a/plugin/webpack.js
+++ b/plugin/webpack.js
@@ -15,14 +15,15 @@ var path = require("path");
 var ResolverFactory = require("enhanced-resolve").ResolverFactory;
 var SyncNodeJsInputFileSystem = require("enhanced-resolve/lib/SyncNodeJsInputFileSystem");
 
-function getResolver(modules, configPath) {
+function getResolver(modules, configPath, alias) {
   var config = {
     unsafeCache: true,
     modules: modules || ["node_modules"],
     extensions: [".js", ".jsx", ".json"],
     aliasFields: ["browser"],
     mainFields: ["browser", "web", "browserify", "main"],
-    fileSystem: new SyncNodeJsInputFileSystem()
+    fileSystem: new SyncNodeJsInputFileSystem(),
+    alias: alias
   }
   var webpackConfig = (configPath && fs.existsSync(configPath)) ? require(configPath) : null
   if (typeof webpackConfig === 'function') {
@@ -73,7 +74,11 @@ tern.registerPlugin("webpack", function(server, options) {
   var configPath = options.configPath || './webpack.config.js'
   var modules = options.modules || ['node_modules']
   configPath = path.resolve(server.options.projectDir, configPath)
-  var resolver = getResolver(modules, configPath)
+  var alias = options.alias || {}
+  Object.keys(alias).forEach(function (key) {
+    alias[key] = path.resolve(server.options.projectDir, alias[key])
+  })
+  var resolver = getResolver(modules, configPath, alias)
   server.loadPlugin("commonjs")
   server.loadPlugin("es_modules")
   server.mod.modules.resolvers.push(function (name, parentFile) {


### PR DESCRIPTION
Right now term supports passing the `configPath` and the `modules` options to the webpack plugin.

As it so happens, webpack 2 natively supports configs to be written using ES6 modules because it transpiles the config using babel if it has the `.babel.js` termination.

There are two ways to solve this as far as I can see.

* Add babel-core as a dependency to tern
* Allow to pass the values directly to the config

The first solution is the best one for users in my opinion, being able to require their babel-esque config would silently fix the issue. If you guys like it we can close this PR and I can open another one that takes care of this.

The second solution is what I'm doing here, allowing to pass `"alias"` to the config should fix the issue for now