### PR TITLE
Introduce way to reverse module resolve order.

### DIFF
--- a/plugin/webpack.js
+++ b/plugin/webpack.js
@@ -76,7 +76,7 @@ tern.registerPlugin("webpack", function(server, options) {
   var resolver = getResolver(modules, configPath)
   server.loadPlugin("commonjs")
   server.loadPlugin("es_modules")
-  server.mod.modules.resolvers.push(function (name, parentFile) {
+  server.mod.modules.resolvers.unshift(function (name, parentFile) {
     var resolved = resolveToFile(resolver, name, parentFile)
     return resolved && infer.cx().parent.normalizeFilename(resolved)
   })


### PR DESCRIPTION
I had an issue where I wanted the webpack plugin to resolve before modules plugin.

I added a way to configure the modules plugin to reverse the order.

I tested this locally with my .tern_project and it works.
I am wondering if this idea is a good idea or not.