### PR TITLE
Ensure webpack.js resolves before modules.js

### DIFF
--- a/plugin/webpack.js
+++ b/plugin/webpack.js
@@ -76,7 +76,7 @@ tern.registerPlugin("webpack", function(server, options) {
   var resolver = getResolver(modules, configPath)
   server.loadPlugin("commonjs")
   server.loadPlugin("es_modules")
-  server.mod.modules.resolvers.push(function (name, parentFile) {
+  server.mod.modules.resolvers.unshift(function (name, parentFile) {
     var resolved = resolveToFile(resolver, name, parentFile)
     return resolved && infer.cx().parent.normalizeFilename(resolved)
   })


### PR DESCRIPTION
I had a webpack configuration where modules.js was
resolving node_modules/foo when I wanted my webpack.config.js to
be resolved instead.

In order to enforce the correct order, I changed the
resolve addition to unshift instead of push to the array.
This ensures webpack resolves before modules.