### PR TITLE
Fix #936: set url-current-object for modified url-open-stream function in emacs 27.0.50

### DIFF
--- a/emacs/tern.el
+++ b/emacs/tern.el
@@ -28,7 +28,8 @@
          (deactivate-mark nil) ; Prevents json-encode from interfering with shift-selection-mode
          (url-request-data (encode-coding-string (json-encode doc) 'utf-8))
          (url-show-status nil)
-         (url (url-parse-make-urlobj "http" nil nil tern-server port "/" nil nil nil)))
+         (url (url-parse-make-urlobj "http" nil nil tern-server port "/" nil nil nil))
+         (url-current-object url))
     (url-http url #'tern-req-finished (list c))))
 
 (defun tern-req-finished (c)


### PR DESCRIPTION
This PR fixes the `Request failed: ((wrong-type-argument url nil))` error in emacs 27.0.50 by setting the `url-current-object`.