### PR TITLE
remove extra computation

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -227,8 +227,9 @@
   }
 
   function similarType(a, b, depth) {
-    if (!a || depth >= 5) return b;
-    if (!a || a == b) return a;
+    if (!a) return b;
+    if (depth >= 5) return b;
+    if (a == b) return a;
     if (!b) return a;
     if (a.constructor != b.constructor) return false;
     if (a.constructor == Arr) {


### PR DESCRIPTION
The reason I noticed this extra computation is because [LGTM](https://lgtm.com/projects/g/ternjs/tern/snapshot/dist-6890063-1513517710448/files/lib/infer.js?sort=name&dir=ASC&mode=heatmap&excluded=false#x24358ccade021ff6:1) was complaining about ` !a ` being evaluated twice.