### PR TITLE
Fix #871 , findExprAt use new Visitor

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1846,9 +1846,19 @@ scope at that point. Returns <code>null</code> if unsuccessful.
 </dt>
 <dd>
 <p>
-Similar to <a href="#infer.findExpressionAround"><code>findExpressionAround</code></a>,
+Similar to <a href="#infer.findExpressionAt"><code>findExpressionAt</code></a>,
 except that it will return the innermost expression node that spans
 the given range, rather than only exact matches.
+</p>
+</dd>
+<dt>
+<a id="infer.findClosestExpression"></a><code>infer.findClosestExpression(ast: AST, start: number?, end: number, scope?: Scope) → {node, state}</code>
+</dt>
+<dd>
+<p>
+Similar to <a href="#infer.findExpressionAround"><code>findExpressionAround</code></a>,
+except that it use the same AST walker as
+<a href="#infer.findExpressionAt"><code>findExpressionAt</code></a>.
 </p>
 </dd>
 <dt>

--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -1129,9 +1129,15 @@ object if successful, where `node` is AST node, and `state` is the
 scope at that point. Returns `null` if unsuccessful.
 
 [[infer.findExpressionAround]]`infer.findExpressionAround(ast: AST, start: number?, end: number, scope?: Scope) → {node, state}`::
-Similar to <<infer.findExpressionAround,`findExpressionAround`>>,
+Similar to <<infer.findExpressionAt,`findExpressionAt`>>,
 except that it will return the innermost expression node that spans
 the given range, rather than only exact matches.
+
+[[infer.findClosestExpression]]`infer.findClosestExpression(ast: AST, start: number?, end: number, scope?: Scope) → {node, state}`::
+Similar to <<infer.findExpressionAround,`findExpressionAround`>>,
+except that it use the same AST walker as 
+<<infer.findExpressionAt,`findExpressionAt`>>.
+  
 
 [[infer.expressionType]]`infer.expressionType(expr: {node, state}) → AVal`::
 Determine an expression for the given node and scope (as returned by

--- a/lib/infer.js
+++ b/lib/infer.js
@@ -2003,6 +2003,16 @@
       c(node.local, st)
     }
   });
+  var searchExprVisitor = exports.searchExprVisitor = walk.make({
+    MemberExpression: function(node, st, c) {
+      c(node.object, st, "Expression");
+      if (node.computed) { c(node.property, st, "Expression"); }
+    },
+    Property: function(node, st, c) {
+      if (node.computed) c(node.key, st, "Expression");
+      c(node.value, st, "Expression");
+    }
+  }, searchVisitor);
   exports.fullVisitor = walk.make({
     MemberExpression: function(node, st, c) {
       c(node.object, st, "Expression");
@@ -2019,7 +2029,15 @@
       if (node.type == "Identifier" && node.name == "✖") return false;
       return typeFinder.hasOwnProperty(node.type);
     };
-    return walk.findNodeAt(ast, start, end, test, searchVisitor, defaultScope || cx.topScope);
+    return walk.findNodeAt(ast, start, end, test, searchExprVisitor, defaultScope || cx.topScope);
+  };
+  exports.findClosestExpression = function(ast, start, end, defaultScope, filter) {
+    var test = filter || function(_t, node) {
+      if (start != null && node.start > start) return false;
+      if (node.type == "Identifier" && node.name == "✖") return false;
+      return typeFinder.hasOwnProperty(node.type);
+    };
+    return walk.findNodeAround(ast, end, test, searchExprVisitor, defaultScope || cx.topScope);
   };
 
   exports.findExpressionAround = function(ast, start, end, defaultScope, filter) {

--- a/lib/tern.js
+++ b/lib/tern.js
@@ -851,15 +851,32 @@
       var start = query.start && resolvePos(file, query.start), end = resolvePos(file, query.end);
       var expr = infer.findExpressionAt(file.ast, start, end, file.scope);
       if (!expr) {
+        var span = infer.findClosestExpression(file.ast, start, end, file.scope);
+        if (span && !inBody(span.node, end) &&
+            (wide || (start == null ? end : start) - span.node.start < 20 || span.node.end - end < 20))
+          expr = span;
+      }
+      if (!expr) {
         var around = infer.findExpressionAround(file.ast, start, end, file.scope);
         if (around && !inBody(around.node, end) &&
             (around.node.type == "ObjectExpression" || wide ||
              (start == null ? end : start) - around.node.start < 20 || around.node.end - end < 20))
-          expr = around
+          expr = around;
       }
       return expr
     }
   };
+
+  function findExprAround(file, query, wide) {
+    var start = query.start && resolvePos(file, query.start), end = resolvePos(file, query.end);
+    var expr = null;
+    var around = infer.findExpressionAround(file.ast, start, end, file.scope);
+    if (around && !inBody(around.node, end) &&
+        (around.node.type == "ObjectExpression" || wide ||
+         (start == null ? end : start) - around.node.start < 20 || around.node.end - end < 20))
+      expr = around
+    return expr
+  }
 
   function findExprOrThrow(file, query, wide) {
     var expr = findExpr(file, query, wide);
@@ -902,8 +919,8 @@
     return type;
   };
 
-  function findTypeAt(srv, query, file) {
-    var expr = findExpr(file, query), exprName;
+  function findTypeAtExpr(srv, query, file, expr) {
+    var exprName, exprType;
     var type = findExprType(srv, query, file, expr), exprType = type;
     if (query.preferFunction)
       type = type.getFunctionType() || type.getType();
@@ -921,6 +938,22 @@
 
     if (query.depth != null && typeof query.depth != "number")
       throw ternError(".query.depth must be a number");
+
+    return [type, exprName, exprType];
+  }
+
+  function findTypeAt(srv, query, file) {
+    var type, exprName, exprType;
+    var expr = findExpr(file, query);
+    var typeResult = findTypeAtExpr(srv, query, file, expr);
+    type = typeResult[0];
+    if (!type) {
+      expr = findExprAround(file, query);
+      typeResult = findTypeAtExpr(srv, query, file, expr);
+      type = typeResult[0];
+    }
+    exprName = typeResult[1];
+    exprType = typeResult[2];
 
     var result = {guess: infer.didGuess(),
                   type: infer.toString(exprType, query.depth),
@@ -950,8 +983,13 @@
   function findDocs(srv, query, file) {
     var expr = findExpr(file, query);
     var type = findExprType(srv, query, file, expr);
-    var result = {url: type.url, doc: parseDoc(query, type.doc), type: infer.toString(type)};
     var inner = type.getType();
+    if (!inner) {
+      expr = findExprAround(file, query);
+      type = findExprType(srv, query, file, expr);
+      inner = type.getType();
+    }
+    var result = {url: type.url, doc: parseDoc(query, type.doc), type: infer.toString(type)};
     if (inner) storeTypeDocs(query, inner, result);
     return clean(result);
   }

--- a/test/cases/object_create.js
+++ b/test/cases/object_create.js
@@ -31,3 +31,15 @@ empty.prop1 = "hi";
 
 empty.hasOwnProperty; //: ?
 empty.prop1; //: string
+
+function create() {
+    // Implementation
+}
+  
+module.exports = {
+  create //loc: 35,9
+};
+  
+module.exports = {
+  create: create //loc: 35,9
+};


### PR DESCRIPTION
findExprAt use fullVisitor, not skip identifier inside object.
findDef/Doc will look around(object) if no result by expr from findExprAt.