### PR TITLE
Handle export default function/class

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -1153,7 +1153,7 @@
       }
     },
     ClassDeclaration: function(node, scope, c) {
-      addVar(scope, node.id)
+      if (node.id) addVar(scope, node.id);
       if (node.superClass) c(node.superClass, scope, "Expression")
       for (var i = 0; i < node.body.body.length; i++)
         c(node.body.body[i], scope)
@@ -1660,16 +1660,24 @@
       infer(node, node.scope || scope, ANull);
     },
 
+    ObjectExpression: function(node, scope) {
+      infer(node, node.scope || scope, ANull);
+    },
+
     FunctionDeclaration: function(node, scope, c) {
       var inner = node.scope, fn = inner.fnType;
       connectParams(node, inner)
       c(node.body, inner, "Statement");
       maybeTagAsInstantiated(node, fn) || maybeTagAsGeneric(fn);
-      scope.getProp(node.id.name).addType(fn)
+      if (node.id) scope.getProp(node.id.name).addType(fn);
     },
 
     Statement: function(node, scope, c) {
       c(node, node.scope || scope)
+    },
+
+    ExportDefaultDeclaration: function(node, scope, c) {
+      c(node.declaration, node.scope || scope)
     },
 
     VariableDeclaration: function(node, scope) {
@@ -1686,7 +1694,8 @@
     },
 
     ClassDeclaration: function(node, scope) {
-      scope.getProp(node.id.name).addType(inferClass(node, scope, node.id.name))
+      if (!node.id) inferClass(node, scope);
+      else scope.getProp(node.id.name).addType(inferClass(node, scope, node.id.name))
     },
 
     ReturnStatement: function(node, scope) {
@@ -1893,8 +1902,14 @@
     ObjectExpression: function(node) {
       return node.objType;
     },
+    ClassDeclaration: function(node) {
+      return node.objType;
+    },
     ClassExpression: function(node) {
       return node.objType;
+    },
+    FunctionDeclaration: function(node) {
+      return node.scope.fnType;
     },
     FunctionExpression: function(node) {
       return node.scope.fnType;

--- a/plugin/es_modules.js
+++ b/plugin/es_modules.js
@@ -19,9 +19,9 @@
         outObj.originNode = file.ast
         out.addType(outObj)
       }
-      var prop = outObj.defProp(prop, originNode)
-      prop.origin = file.name
-      type.propagate(prop)
+      var propObj = outObj.defProp(prop, originNode)
+      propObj.origin = file.name
+      type.propagate(propObj)
     }
 
     walk.simple(file.ast, {

--- a/test/cases/es_modules/class.js
+++ b/test/cases/es_modules/class.js
@@ -1,0 +1,4 @@
+export default class {
+  methodA() {
+  }
+};

--- a/test/cases/es_modules/func.js
+++ b/test/cases/es_modules/func.js
@@ -1,0 +1,1 @@
+export default function () { return true; }

--- a/test/cases/es_modules/main.js
+++ b/test/cases/es_modules/main.js
@@ -19,3 +19,16 @@ import * as reexp from "./reexp"
 reexp //:: {a: number, b: bool}
 
 import "./b" //+ "./blah"
+
+import C from "./class"
+
+(new C()). //+ methodA
+
+import f from "./func"
+
+f //: fn() -> bool
+
+import o from "./obj"
+
+o.propA //: number
+o.propB //: string

--- a/test/cases/es_modules/obj.js
+++ b/test/cases/es_modules/obj.js
@@ -1,0 +1,1 @@
+export default {propA: 1, propB: "str"}


### PR DESCRIPTION
`export default` function/class is declaration but allow anonymous form.
And this kind of syntax will cause TernJS crash.
This PR handle these kind of syntax.