### PR TITLE
Clarify docstring for tern-command var

### DIFF
--- a/emacs/tern.el
+++ b/emacs/tern.el
@@ -102,8 +102,14 @@
     (if (file-exists-p bin-file)
         (if (eq system-type 'windows-nt) (list "node" bin-file) (list bin-file))
       (list "tern")))
-  "The command to be run to start the Tern server. Should be a
-list of strings, giving the binary name and arguments.")
+  "Location of the tern server binary command and options.
+
+This is a quoted list of strings representing the command and
+optional arguments to run the Tern server.
+
+Examples:
+(setq tern-command '(\"/home/jane/.nvm/versions/node/v10.13.0/bin/tern\"))
+(setq tern-command '(\"/home/jane/.nvm/versions/node/v10.13.0/bin/tern\" \"--strip-crs\"))")
 
 (defun tern-start-server (c)
   (let* ((default-directory (tern-project-dir))


### PR DESCRIPTION
Hi, I am trying to get the tern working in my emacs 25 and am having problems.

So one of the things I stumbled across in trying to get it running was that I was trying to set **tern-command** to a **string**, when the docs did already say that it needed to be a **list** of strings. But I missed it when doing the C-h v string-doc help inside emacs.

So I am contributing this in hopes that it will make it more blatantly obvious to newbies like me, what needs to be done, and save them the time that I wasted. Thanks for considering the pull!