### PR TITLE
Make bootstrapping of a Tern server easier

### DIFF
--- a/bin/tern
+++ b/bin/tern
@@ -2,15 +2,13 @@
 
 // HTTP server for desktop editors
 
-// Reads .tern-project files, wraps a Tern server in an HTTP wrapper
+// Starts a Tern server and wraps it in an HTTP wrapper
 // so that editor plug-ins can talk to it.
 
-var tern = require("../lib/tern");
+var boostrapServer = require('../lib/bootstrap');
 var fs = require("fs"), path = require("path"), url = require("url");
-var glob = require("glob"), minimatch = require("minimatch");
-var resolveFrom = require("resolve-from");
 
-var projectFileName = ".tern-project", portFileName = ".tern-port";
+var portFileName = ".tern-port";
 var maxIdleTime = 6e4 * 5; // Shut down after five minutes of inactivity
 
 var persistent = process.argv.indexOf("--persistent") > -1;
@@ -33,115 +31,6 @@ if (portArg > -1) {
 }
 var ignoreStdin = process.argv.indexOf("--ignore-stdin") > -1;
 
-function findProjectDir() {
-  var dir = process.cwd();
-  for (;;) {
-    try {
-      if (fs.statSync(path.resolve(dir, projectFileName)).isFile()) return dir;
-    } catch(e) {}
-    var shorter = path.dirname(dir);
-    if (shorter == dir) return null;
-    dir = shorter;
-  }
-}
-
-var defaultConfig = {
-  libs: [],
-  loadEagerly: false,
-  plugins: {doc_comment: true},
-  ecmaScript: true,
-  ecmaVersion: 9,
-  dependencyBudget: tern.defaultOptions.dependencyBudget
-};
-var homeDir = process.env.HOME || process.env.USERPROFILE;
-if (homeDir && fs.existsSync(path.resolve(homeDir, ".tern-config")))
-  defaultConfig = readProjectFile(path.resolve(homeDir, ".tern-config"));
-
-function readJSON(fileName) {
-  var file = fs.readFileSync(fileName, "utf8");
-  try {
-    return JSON.parse(file);
-  } catch (e) {
-    console.error("Bad JSON in " + fileName + ": " + e.message);
-    process.exit(1);
-  }
-}
-
-function readProjectFile(fileName) {
-  var data = readJSON(fileName), name;
-  for (var option in defaultConfig) {
-    if (!data.hasOwnProperty(option))
-      data[option] = defaultConfig[option];
-    else if (option == "plugins")
-      for (name in defaultConfig.plugins)
-        if (!Object.prototype.hasOwnProperty.call(data.plugins, name))
-          data.plugins[name] = defaultConfig.plugins[name];
-  }
-  return data;
-}
-
-function findFile(file, projectDir, fallbackDir) {
-  var local = path.resolve(projectDir, file);
-  if (!disableLoadingLocal && fs.existsSync(local)) return local;
-  var shared = path.resolve(fallbackDir, file);
-  if (fs.existsSync(shared)) return shared;
-}
-
-var distDir = path.resolve(__dirname, "..");
-
-function findDefs(projectDir, config) {
-  var defs = [], src = config.libs.slice();
-  if (config.ecmaScript && src.indexOf("ecmascript") == -1)
-    src.unshift("ecmascript");
-  for (var i = 0; i < src.length; ++i) {
-    var file = src[i];
-    if (!/\.json$/.test(file)) file = file + ".json";
-    var found = findFile(file, projectDir, path.resolve(distDir, "defs"))
-        || resolveFrom(projectDir, "tern-" + src[i]);
-    if (!found) {
-      try {
-        found = require.resolve("tern-" + src[i]);
-      } catch (e) {
-        process.stderr.write("Failed to find library " + src[i] + ".\n");
-        continue;
-      }
-    }
-    if (found) defs.push(readJSON(found));
-  }
-  return defs;
-}
-
-function loadPlugins(projectDir, config) {
-  var plugins = config.plugins, options = {};
-  for (var plugin in plugins) {
-    var val = plugins[plugin];
-    if (!val) continue;
-    var found = findFile(plugin + ".js", projectDir, path.resolve(distDir, "plugin"))
-        || resolveFrom(projectDir, "tern-" + plugin);
-    if (!found) {
-      try {
-        found = require.resolve("tern-" + plugin);
-      } catch (e) {
-        process.stderr.write("Failed to find plugin " + plugin + ".\n");
-        continue;
-      }
-    }
-    var mod = require(found);
-    if (mod.hasOwnProperty("initialize")) mod.initialize(distDir);
-    options[path.basename(plugin)] = val;
-  }
-
-  return options;
-}
-
-var projectDir = findProjectDir();
-if (projectDir) {
-  var config = readProjectFile(path.resolve(projectDir, projectFileName));
-} else {
-  projectDir = process.cwd();
-  var config = defaultConfig;
-}
-
 var httpServer = require("http").createServer(function(req, resp) {
   clearTimeout(shutdown);
   shutdown = setTimeout(doShutdown, maxIdleTime);
@@ -160,43 +49,15 @@ var httpServer = require("http").createServer(function(req, resp) {
   }
 });
 
-var server = startServer(projectDir, config, httpServer);
-
-function startServer(dir, config, httpServer) {
-  var defs = findDefs(dir, config);
-  var plugins = loadPlugins(dir, config);
-  var server = new tern.Server({
-    getFile: function(name, c) {
-      if (config.dontLoad && config.dontLoad.some(function(pat) {return minimatch(name, pat)}))
-        c(null, "");
-      else
-        fs.readFile(path.resolve(dir, name), "utf8", c);
-    },
-    normalizeFilename: function(name) {
-      var pt = path.resolve(dir, name);
-      try { pt = fs.realPathSync(path.resolve(dir, name), true) }
-      catch(e) {}
-      return path.relative(dir, pt);
-    },
-    async: true,
-    defs: defs,
-    plugins: plugins,
-    debug: debug,
-    projectDir: dir,
-    ecmaVersion: config.ecmaVersion,
-    dependencyBudget: config.dependencyBudget,
+var serverConfig = {
+  disableLoadingLocal: disableLoadingLocal,
+  tern: {
     stripCRs: stripCRs,
-    parent: {httpServer: httpServer}
-  });
-
-  if (config.loadEagerly) config.loadEagerly.forEach(function(pat) {
-    glob.sync(pat, { cwd: dir }).forEach(function(file) {
-      server.addFile(file);
-    });
-  });
-  server.flush(function(){});
-  return server;
-}
+    debug: debug,
+    parent: { httpServer: httpServer }
+  }
+};
+var server = boostrapServer(serverConfig);
 
 function doShutdown() {
   if (persistent) return;
@@ -217,7 +78,7 @@ if (!ignoreStdin) {
 httpServer.listen(port, host, function() {
   var port = httpServer.address().port;
   if (!noPortFile) {
-    var portFile = path.resolve(projectDir, portFileName);
+    var portFile = path.resolve(server.projectDir, portFileName);
     fs.writeFileSync(portFile, String(port), "utf8");
     process.on("exit", function() {
       try {

--- a/bin/tern
+++ b/bin/tern
@@ -5,7 +5,7 @@
 // Starts a Tern server and wraps it in an HTTP wrapper
 // so that editor plug-ins can talk to it.
 
-var boostrapServer = require('../lib/bootstrap');
+var bootstrapServer = require('../lib/bootstrap');
 var fs = require("fs"), path = require("path"), url = require("url");
 
 var portFileName = ".tern-port";
@@ -57,7 +57,7 @@ var serverConfig = {
     parent: { httpServer: httpServer }
   }
 };
-var server = boostrapServer(serverConfig);
+var server = bootstrapServer(serverConfig);
 
 function doShutdown() {
   if (persistent) return;

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -1,0 +1,163 @@
+var tern = require("./tern");
+var fs = require("fs"), path = require("path"), url = require("url");
+var glob = require("glob"), minimatch = require("minimatch");
+var resolveFrom = require("resolve-from");
+
+var projectFileName = ".tern-project", portFileName = ".tern-port";
+
+function findProjectDir() {
+  var dir = process.cwd();
+  for (;;) {
+    try {
+      if (fs.statSync(path.resolve(dir, projectFileName)).isFile()) return dir;
+    } catch(e) {}
+    var shorter = path.dirname(dir);
+    if (shorter == dir) return null;
+    dir = shorter;
+  }
+}
+
+var defaultConfig = {
+  libs: [],
+  loadEagerly: false,
+  plugins: {doc_comment: true},
+  ecmaScript: true,
+  ecmaVersion: 9,
+  dependencyBudget: tern.defaultOptions.dependencyBudget
+};
+var homeDir = process.env.HOME || process.env.USERPROFILE;
+if (homeDir && fs.existsSync(path.resolve(homeDir, ".tern-config")))
+  defaultConfig = readProjectFile(path.resolve(homeDir, ".tern-config"));
+
+function readJSON(fileName) {
+  var file = fs.readFileSync(fileName, "utf8");
+  try {
+    return JSON.parse(file);
+  } catch (e) {
+    console.error("Bad JSON in " + fileName + ": " + e.message);
+    process.exit(1);
+  }
+}
+
+function readProjectFile(fileName) {
+  var data = readJSON(fileName), name;
+  for (var option in defaultConfig) {
+    if (!data.hasOwnProperty(option))
+      data[option] = defaultConfig[option];
+    else if (option == "plugins")
+      for (name in defaultConfig.plugins)
+        if (!Object.prototype.hasOwnProperty.call(data.plugins, name))
+          data.plugins[name] = defaultConfig.plugins[name];
+  }
+  return data;
+}
+
+function findFile(file, projectDir, fallbackDir, options) {
+  var local = path.resolve(projectDir, file);
+  if (!options.disableLoadingLocal && fs.existsSync(local)) return local;
+  var shared = path.resolve(fallbackDir, file);
+  if (fs.existsSync(shared)) return shared;
+}
+
+var distDir = path.resolve(__dirname, "..");
+
+function findDefs(projectDir, config, options) {
+  var defs = [], src = config.libs.slice();
+  if (config.ecmaScript && src.indexOf("ecmascript") == -1)
+    src.unshift("ecmascript");
+  for (var i = 0; i < src.length; ++i) {
+    var file = src[i];
+    if (!/\.json$/.test(file)) file = file + ".json";
+    var found = findFile(file, projectDir, path.resolve(distDir, "defs"), options)
+        || resolveFrom(projectDir, "tern-" + src[i]);
+    if (!found) {
+      try {
+        found = require.resolve("tern-" + src[i]);
+      } catch (e) {
+        process.stderr.write("Failed to find library " + src[i] + ".\n");
+        continue;
+      }
+    }
+    if (found) defs.push(readJSON(found));
+  }
+  return defs;
+}
+
+function loadPlugins(projectDir, config, options) {
+  var plugins = config.plugins, options = {};
+  for (var plugin in plugins) {
+    var val = plugins[plugin];
+    if (!val) continue;
+    var found = findFile(plugin + ".js", projectDir, path.resolve(distDir, "plugin"), options)
+        || resolveFrom(projectDir, "tern-" + plugin);
+    if (!found) {
+      try {
+        found = require.resolve("tern-" + plugin);
+      } catch (e) {
+        process.stderr.write("Failed to find plugin " + plugin + ".\n");
+        continue;
+      }
+    }
+    var mod = require(found);
+    if (mod.hasOwnProperty("initialize")) mod.initialize(distDir);
+    options[path.basename(plugin)] = val;
+  }
+
+  return options;
+}
+
+function startServer(dir, config, options) {
+  var defs = findDefs(dir, config, options);
+  var plugins = loadPlugins(dir, config, options);
+  var ternConfig = {
+    getFile: function(name, c) {
+      if (config.dontLoad && config.dontLoad.some(function(pat) {return minimatch(name, pat)}))
+        c(null, "");
+      else
+        fs.readFile(path.resolve(dir, name), "utf8", c);
+    },
+    normalizeFilename: function(name) {
+      var pt = path.resolve(dir, name);
+      try { pt = fs.realPathSync(path.resolve(dir, name), true) }
+      catch(e) {}
+      return path.relative(dir, pt);
+    },
+    async: true,
+    defs: defs,
+    plugins: plugins,
+    projectDir: dir,
+    ecmaVersion: config.ecmaVersion,
+    dependencyBudget: config.dependencyBudget,
+  };
+  if (options.tern) {
+    for (var option in options.tern) {
+      if (options.tern.hasOwnProperty(option)) {
+        ternConfig[option] = options.tern[option];
+      }
+    }
+  }
+  var server = new tern.Server(ternConfig);
+
+  if (config.loadEagerly) config.loadEagerly.forEach(function(pat) {
+    glob.sync(pat, { cwd: dir }).forEach(function(file) {
+      server.addFile(file);
+    });
+  });
+  server.flush(function(){});
+  return server;
+}
+
+module.exports = function boostrapServer(options) {
+  var projectDir = options.projectDir;
+  if (!projectDir) {
+    projectDir = findProjectDir();
+  }
+
+  if (projectDir) {
+    var config = readProjectFile(path.resolve(projectDir, projectFileName));
+  } else {
+    projectDir = process.cwd();
+    var config = defaultConfig;
+  }
+  return startServer(projectDir, config, options);
+}

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -147,7 +147,7 @@ function startServer(dir, config, options) {
   return server;
 }
 
-module.exports = function boostrapServer(options) {
+module.exports = function bootstrapServer(options) {
   var projectDir = options.projectDir;
   if (!projectDir) {
     projectDir = findProjectDir();


### PR DESCRIPTION
As of today, if people wanted to use Tern without the HTTP server wrapper they would be forced to re-implement most of the server-bootstrap logic already implemented inside bin/tern like:

- conditional parsing of .tern-config / .tern-project files
- set up of used libraries (i.e. defs)
- set up of plugins
- preload of "loadEagerly" files

With this commit I am moving most of this logic from bin/tern into lib/bootstrap.js and changing bin/tern to source that to start the Tern server.