### PR TITLE
[bugfix] jsdoc - single word tags

### DIFF
--- a/plugin/doc_comment.js
+++ b/plugin/doc_comment.js
@@ -390,12 +390,14 @@
 
     for (var i = 0; i < comments.length; ++i) {
       var comment = comments[i];
-      var decl = /(?:\n|\*)\s*@(type|param|arg(?:ument)?|returns?|this|class|constructor)\s+(.*)/g, m;
+      var decl = /(?:\n|\*)\s*@(type|param|arg(?:ument)?|returns?|this|class|constructor)(?:\s*?\n|\s+(.*))/g, m;
       while (m = decl.exec(comment)) {
         if (m[1] == "class" || m[1] == "constructor") {
           self = foundOne = true;
           continue;
         }
+
+        if (m[2] === undefined) continue; // to avoid tags that require a type argument.
 
         if (m[1] == "this" && (parsed = parseType(scope, m[2], 0))) {
           self = parsed;


### PR DESCRIPTION
fixed a bug in the doc_comment plugin, in which tags of a single word would cause the pattern to match two tags at once.
example:
```javascript
/**
 * a test
 * @constructor // single word
 * @param {Object} param1 // would be interpreted as the type of constructor
 * @param {number} param2
 */
function test(param1, param2) {
    return `${param1} - ${param2}`;
}
```
function signature: `fn(param1: ?, param2: number) -> string`
notice the type of param1 is missing because its tag is mis-matched.