### PR TITLE
 'window.open()' trigger doesn't show DOM window object properties

### DIFF
--- a/defs/browser.json
+++ b/defs/browser.json
@@ -3394,6 +3394,11 @@
     "!url": "https://developer.mozilla.org/en/docs/DOM/window.onabort",
     "!doc": "An event handler for abort events sent to the window."
   },
+  "open": {
+    "!type": "fn(url: string, name: string, specs: string, replace: bool) -> <top>",
+    "!url": "https://www.w3schools.com/jsref/met_win_open.asp",
+    "!doc": "opens a new browser window, or a new tab, depending on your browser settings"
+  },    
   "getSelection": {
     "!type": "fn() -> +Selection",
     "!url": "https://developer.mozilla.org/en/docs/DOM/window.getSelection",

--- a/defs/browser.json
+++ b/defs/browser.json
@@ -3396,7 +3396,7 @@
   },
   "open": {
     "!type": "fn(url: string, name: string, specs: string, replace: bool) -> <top>",
-    "!url": "https://www.w3schools.com/jsref/met_win_open.asp",
+    "!url": "https://developer.mozilla.org/en-US/docs/Web/API/Window/open",
     "!doc": "opens a new browser window, or a new tab, depending on your browser settings"
   },    
   "getSelection": {


### PR DESCRIPTION
It was because browser.json is not having that entry .I have added that entry into json