### PR TITLE
Fix TypeError in doc_comment.js

### DIFF
--- a/plugin/doc_comment.js
+++ b/plugin/doc_comment.js
@@ -94,6 +94,7 @@
         }
       },
       Class: function(node, scope) {
+        if (!node.objType) return;
         var proto = node.objType.getProp("prototype").getObjType();
         if (!proto) return;
         for (var i = 0; i < node.body.body.length; i++) {


### PR DESCRIPTION
When editing vue files ternjs is crashing with following error:
```
        var proto = node.objType.getProp("prototype").getObjType();
                                 ^
TypeError: Cannot read property 'getProp' of undefined
```

This change fixed it.