### PR TITLE
Remove note about looking for a maintainer from website

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,10 +32,6 @@ JavaScript, and capable of running both
 on <a href="http://nodejs.org">node.js</a> and in
 the <a href="doc/demo/index.html">browser</a>.</p>
 
-<p><strong>NOTE</strong>: This project is looking for a new
-maintainer, since the original author no longer has time to work on
-it.</p>
-
 <h2><a id="plugins"></a>Editor plugins</h2>
 
 <p>There is currently Tern support for the following editors:</p>


### PR DESCRIPTION
The website still mentions the project is looking for a maintainer. Do you want to remove that?