### PR TITLE
Fix typo in property name

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -1178,7 +1178,7 @@
 
   function rmScope(node) { if (node.scope) node.scope = null }
   var scopeClearer = {BlockStatement: rmScope, Function: rmScope, CatchClause: rmScope,
-                      ForInStateMent: rmScope, ForStatement: rmScope};
+                      ForInStatement: rmScope, ForStatement: rmScope};
   exports.clearScopes = function(ast) {
     walk.simple(ast, scopeClearer);
   };


### PR DESCRIPTION
Fix casing of the ForInStatement property. Bug appears to have been
introduced in commit 3f4794d ("Clear scopes on AST before analysis")
from December 2016.