### PR TITLE
Update ecmascript.json

### DIFF
--- a/defs/ecmascript.json
+++ b/defs/ecmascript.json
@@ -914,7 +914,12 @@
   "Boolean": {
     "!type": "fn(value: ?) -> bool",
     "prototype": {
-      "!stdProto": "Boolean"
+      "!stdProto": "Boolean",
+      "valueOf": {
+        "!type": "fn() -> bool",
+        "!url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf",
+        "!doc": "Returns the primitive value of a Boolean object."
+      }
     },
     "!url": "https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Boolean",
     "!doc": "The Boolean object is an object wrapper for a boolean value."


### PR DESCRIPTION
Add "valueOf" to Boolean prototype to return the proper type. Boolean's stdProto's valueOf returns a number type, whereas Boolean's valueOf should return a boolean type.